### PR TITLE
Replace inline CI simulator bash with Python orchestration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,11 @@ jobs:
           echo "All must-pass features passing."
 
       - name: Run iOS Simulator tests
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: >
           python3 scripts/ci/ci_ios_test.py
           --tier 2 --timeout 90 --safe-only --skip-regen --skip-build
+          --step-timeout 840
 
       - name: Upload simulator diagnostics
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,57 +115,21 @@ jobs:
           fi
           echo "All must-pass features passing."
 
-      - name: Boot iOS Simulator
-        id: boot-sim
-        timeout-minutes: 5
-        run: |
-          DEVICE=$(xcrun simctl list devices available -j | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          prefs = ['iPhone 16', 'iPhone 17 Pro', 'iPhone 15 Pro']
-          for runtime, devices in data['devices'].items():
-              if 'iOS' not in runtime: continue
-              for pref in prefs:
-                  for d in devices:
-                      if d['name'] == pref and d['state'] != 'Booted':
-                          print(d['udid']); sys.exit(0)
-          for runtime, devices in data['devices'].items():
-              if 'iOS' not in runtime: continue
-              for d in devices:
-                  if d.get('isAvailable') and 'iPhone' in d['name']:
-                      print(d['udid']); sys.exit(0)
-          sys.exit(1)
-          ")
-          echo "Booting simulator: $DEVICE"
-          xcrun simctl boot "$DEVICE" 2>/dev/null || true
-          # Poll for Booted state (bootstatus -b hangs on GHA macos runners)
-          for i in $(seq 1 60); do
-            STATE=$(xcrun simctl list devices "$DEVICE" -j | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          for r, devs in data['devices'].items():
-              for d in devs:
-                  if d['udid'] == '$DEVICE':
-                      print(d['state']); sys.exit(0)
-          ")
-            if [ "$STATE" = "Booted" ]; then
-              echo "Simulator booted after ${i}s"
-              break
-            fi
-            sleep 1
-          done
-          if [ "$STATE" != "Booted" ]; then
-            echo "ERROR: Simulator failed to boot within 60s (state: $STATE)"
-            exit 1
-          fi
-          echo "device_udid=$DEVICE" >> "$GITHUB_OUTPUT"
-
-      - name: Run runtime tests (iOS)
+      - name: Run iOS Simulator tests
         timeout-minutes: 10
         run: >
-          cd TestFramework &&
-          ./run-runtime-tests.sh --tier 2 --timeout 90 --safe-only --skip-regen
-          --device-udid ${{ steps.boot-sim.outputs.device_udid }}
+          python3 scripts/ci/ci_ios_test.py
+          --reuse-device
+          --tier 2 --timeout 90 --safe-only --skip-regen --skip-build
+
+      - name: Upload simulator diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-diagnostics
+          path: /tmp/sim-diagnostics/
+          retention-days: 7
+          if-no-files-found: ignore
 
   package-smoke:
     name: Package Smoke Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,11 @@ jobs:
           echo "All must-pass features passing."
 
       - name: Run iOS Simulator tests
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: >
           python3 scripts/ci/ci_ios_test.py
           --tier 2 --timeout 90 --safe-only --skip-regen --skip-build
-          --step-timeout 840
+          --step-timeout 1140
 
       - name: Upload simulator diagnostics
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,6 @@ jobs:
         timeout-minutes: 10
         run: >
           python3 scripts/ci/ci_ios_test.py
-          --reuse-device
           --tier 2 --timeout 90 --safe-only --skip-regen --skip-build
 
       - name: Upload simulator diagnostics

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,10 +116,11 @@ jobs:
           echo "All must-pass features passing."
 
       - name: Run iOS Simulator tests
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: >
           python3 scripts/ci/ci_ios_test.py
           --tier 2 --timeout 90 --safe-only --skip-regen --skip-build
+          --step-timeout 840
 
       - name: Upload simulator diagnostics
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,11 +116,11 @@ jobs:
           echo "All must-pass features passing."
 
       - name: Run iOS Simulator tests
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: >
           python3 scripts/ci/ci_ios_test.py
           --tier 2 --timeout 90 --safe-only --skip-regen --skip-build
-          --step-timeout 840
+          --step-timeout 1140
 
       - name: Upload simulator diagnostics
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,57 +115,21 @@ jobs:
           fi
           echo "All must-pass features passing."
 
-      - name: Boot iOS Simulator
-        id: boot-sim
-        timeout-minutes: 5
-        run: |
-          DEVICE=$(xcrun simctl list devices available -j | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          prefs = ['iPhone 16', 'iPhone 17 Pro', 'iPhone 15 Pro']
-          for runtime, devices in data['devices'].items():
-              if 'iOS' not in runtime: continue
-              for pref in prefs:
-                  for d in devices:
-                      if d['name'] == pref and d['state'] != 'Booted':
-                          print(d['udid']); sys.exit(0)
-          for runtime, devices in data['devices'].items():
-              if 'iOS' not in runtime: continue
-              for d in devices:
-                  if d.get('isAvailable') and 'iPhone' in d['name']:
-                      print(d['udid']); sys.exit(0)
-          sys.exit(1)
-          ")
-          echo "Booting simulator: $DEVICE"
-          xcrun simctl boot "$DEVICE" 2>/dev/null || true
-          # Poll for Booted state (bootstatus -b hangs on GHA macos runners)
-          for i in $(seq 1 60); do
-            STATE=$(xcrun simctl list devices "$DEVICE" -j | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          for r, devs in data['devices'].items():
-              for d in devs:
-                  if d['udid'] == '$DEVICE':
-                      print(d['state']); sys.exit(0)
-          ")
-            if [ "$STATE" = "Booted" ]; then
-              echo "Simulator booted after ${i}s"
-              break
-            fi
-            sleep 1
-          done
-          if [ "$STATE" != "Booted" ]; then
-            echo "ERROR: Simulator failed to boot within 60s (state: $STATE)"
-            exit 1
-          fi
-          echo "device_udid=$DEVICE" >> "$GITHUB_OUTPUT"
-
-      - name: Run runtime tests (iOS)
+      - name: Run iOS Simulator tests
         timeout-minutes: 10
         run: >
-          cd TestFramework &&
-          ./run-runtime-tests.sh --tier 2 --timeout 90 --safe-only --skip-regen
-          --device-udid ${{ steps.boot-sim.outputs.device_udid }}
+          python3 scripts/ci/ci_ios_test.py
+          --reuse-device
+          --tier 2 --timeout 90 --safe-only --skip-regen --skip-build
+
+      - name: Upload simulator diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-diagnostics
+          path: /tmp/sim-diagnostics/
+          retention-days: 7
+          if-no-files-found: ignore
 
   # --- Release ---
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,6 @@ jobs:
         timeout-minutes: 10
         run: >
           python3 scripts/ci/ci_ios_test.py
-          --reuse-device
           --tier 2 --timeout 90 --safe-only --skip-regen --skip-build
 
       - name: Upload simulator diagnostics

--- a/.validation-baseline.json
+++ b/.validation-baseline.json
@@ -1,5 +1,5 @@
 {
-  "git_sha": "280f6e2e",
+  "git_sha": "5252aab9",
   "compile_gate": {
     "libraries": {
       "Alamofire": {
@@ -29,13 +29,13 @@
       "CryptoSwift": {
         "compile": "ok",
         "errors": 0,
-        "lines": 24617,
+        "lines": 24609,
         "dep_compile": "none"
       },
       "GRDB": {
         "compile": "ok",
         "errors": 0,
-        "lines": 91886,
+        "lines": 91883,
         "dep_compile": "none"
       },
       "KeychainAccess": {
@@ -77,19 +77,19 @@
       "Nuke": {
         "compile": "ok",
         "errors": 0,
-        "lines": 21842,
+        "lines": 21840,
         "dep_compile": "none"
       },
       "Nuke@macos": {
         "compile": "ok",
         "errors": 0,
-        "lines": 21842,
+        "lines": 21840,
         "dep_compile": "none"
       },
       "Nuke@tvos": {
         "compile": "ok",
         "errors": 0,
-        "lines": 21842,
+        "lines": 21840,
         "dep_compile": "none"
       },
       "RxSwift": {

--- a/.validation-baseline.json
+++ b/.validation-baseline.json
@@ -1,11 +1,11 @@
 {
-  "git_sha": "5252aab9",
+  "git_sha": "4228248c",
   "compile_gate": {
     "libraries": {
       "Alamofire": {
         "compile": "ok",
         "errors": 0,
-        "lines": 53912,
+        "lines": 53907,
         "dep_compile": "none"
       },
       "BlinkID": {
@@ -29,19 +29,19 @@
       "CryptoSwift": {
         "compile": "ok",
         "errors": 0,
-        "lines": 24609,
+        "lines": 24590,
         "dep_compile": "none"
       },
       "GRDB": {
         "compile": "ok",
         "errors": 0,
-        "lines": 91883,
+        "lines": 91879,
         "dep_compile": "none"
       },
       "KeychainAccess": {
         "compile": "ok",
         "errors": 0,
-        "lines": 4606,
+        "lines": 4604,
         "dep_compile": "none"
       },
       "Kingfisher": {
@@ -53,7 +53,7 @@
       "Lottie": {
         "compile": "ok",
         "errors": 0,
-        "lines": 31963,
+        "lines": 31961,
         "dep_compile": "none"
       },
       "Mappedin": {
@@ -65,7 +65,7 @@
       "MicroblinkPlatform": {
         "compile": "ok",
         "errors": 0,
-        "lines": 4568,
+        "lines": 4567,
         "dep_compile": "none"
       },
       "Mixpanel": {
@@ -77,37 +77,37 @@
       "Nuke": {
         "compile": "ok",
         "errors": 0,
-        "lines": 21840,
+        "lines": 21838,
         "dep_compile": "none"
       },
       "Nuke@macos": {
         "compile": "ok",
         "errors": 0,
-        "lines": 21840,
+        "lines": 21838,
         "dep_compile": "none"
       },
       "Nuke@tvos": {
         "compile": "ok",
         "errors": 0,
-        "lines": 21840,
+        "lines": 21838,
         "dep_compile": "none"
       },
       "RxSwift": {
         "compile": "ok",
         "errors": 0,
-        "lines": 18827,
+        "lines": 18822,
         "dep_compile": "none"
       },
       "SkeletonView": {
         "compile": "ok",
         "errors": 0,
-        "lines": 14290,
+        "lines": 14288,
         "dep_compile": "none"
       },
       "SmartCardIO": {
         "compile": "ok",
         "errors": 0,
-        "lines": 5371,
+        "lines": 5361,
         "dep_compile": "none"
       },
       "SnapKit": {
@@ -119,7 +119,7 @@
       "Starscream": {
         "compile": "ok",
         "errors": 0,
-        "lines": 15725,
+        "lines": 15722,
         "dep_compile": "none"
       },
       "Stripe": {
@@ -149,13 +149,13 @@
       "StripeConnect": {
         "compile": "dep_only",
         "errors": 0,
-        "lines": 12354,
+        "lines": 12349,
         "dep_compile": "ok"
       },
       "StripeCore": {
         "compile": "ok",
         "errors": 0,
-        "lines": 33934,
+        "lines": 33930,
         "dep_compile": "none"
       },
       "StripeCryptoOnramp": {
@@ -179,19 +179,19 @@
       "StripeIssuing": {
         "compile": "dep_only",
         "errors": 0,
-        "lines": 1836,
+        "lines": 1833,
         "dep_compile": "ok"
       },
       "StripePayments": {
         "compile": "dep_only",
         "errors": 0,
-        "lines": 75999,
+        "lines": 75994,
         "dep_compile": "ok"
       },
       "StripePaymentSheet": {
         "compile": "dep_only",
         "errors": 0,
-        "lines": 50711,
+        "lines": 50709,
         "dep_compile": "ok"
       },
       "StripePaymentsUI": {
@@ -227,13 +227,13 @@
       "Swinject": {
         "compile": "ok",
         "errors": 0,
-        "lines": 5101,
+        "lines": 5100,
         "dep_compile": "none"
       },
       "PhoneNumberKit": {
         "compile": "ok",
         "errors": 0,
-        "lines": 15441,
+        "lines": 15439,
         "dep_compile": "none"
       },
       "Valet": {
@@ -275,7 +275,7 @@
       "Parchment": {
         "compile": "ok",
         "errors": 0,
-        "lines": 17581,
+        "lines": 17579,
         "dep_compile": "none"
       },
       "KeychainSwift": {
@@ -329,7 +329,7 @@
       "XMLCoder": {
         "compile": "fail",
         "errors": 2,
-        "lines": 22125,
+        "lines": 22124,
         "dep_compile": "none"
       },
       "AnimatedCollectionViewLayout": {

--- a/TestFramework/golden/SwiftBindingsTestLib.cs.golden
+++ b/TestFramework/golden/SwiftBindingsTestLib.cs.golden
@@ -37348,16 +37348,16 @@ public partial class SimplePriorityHandler : ISwiftObject, IDisposable, IPriorit
         unsafe
         {
             _payload = new SwiftSafeHandle<SimplePriorityHandler>((IntPtr)NativeMemory.Alloc(_payloadSize));
-            var swiftIndirectResult = new SwiftIndirectResult((void*)_payload.DangerousGetHandle());
+            var resultPtr = _payload.DangerousGetHandle();
             
-            PInvoke_init_30836628(swiftIndirectResult);
+            PInvoke_init_5BDAC20F(resultPtr);
             
         }
     }
     
-    [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
-    [LibraryImport("SwiftBindingsTestLibSwiftBindings", EntryPoint = "DBW_SimplePriorityHandler_init_FC07C5C0_1")]
-    private static partial void PInvoke_init_30836628( SwiftIndirectResult swiftIndirectResult);
+    [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+    [LibraryImport("SwiftBindingsTestLibSwiftBindings", EntryPoint = "SBW_SwiftBindingsTestLib_SimplePriorityHandler_init_30836628")]
+    private static partial void PInvoke_init_5BDAC20F( IntPtr resultPtr);
     
     
     /// <summary>

--- a/scripts/ci/ci_ios_test.py
+++ b/scripts/ci/ci_ios_test.py
@@ -119,11 +119,14 @@ def run_tests(
     timeout: int = 90,
     safe_only: bool = True,
     skip_regen: bool = True,
+    max_test_retries: int = 1,
 ) -> int:
     """Run runtime tests using the existing run-runtime-tests.sh script.
 
     We delegate to the existing script to preserve all the nuanced crash
     detection, Mono JIT tolerance, and result classification logic.
+
+    Retries once on timeout/infrastructure failure (app hang, launch failure).
 
     Returns:
         Exit code from run-runtime-tests.sh
@@ -139,21 +142,55 @@ def run_tests(
     if skip_regen:
         cmd.append("--skip-regen")
 
-    log.info("=== TESTS: Running runtime tests (tier=%d, timeout=%ds) ===", tier, timeout)
-    log.info("Command: %s", " ".join(cmd))
+    for attempt in range(1, max_test_retries + 2):
+        if attempt > 1:
+            log.info("=== TESTS: Retry attempt %d (previous run timed out) ===", attempt)
+            gha_warning(f"Test retry attempt {attempt} after timeout/hang")
 
-    result = subprocess.run(
-        cmd,
-        cwd=test_framework_dir,
-        timeout=timeout + 300,  # run-runtime-tests.sh builds wrappers+bridge+app before tests
-    )
+        log.info("=== TESTS: Running runtime tests (tier=%d, timeout=%ds, attempt=%d) ===",
+                 tier, timeout, attempt)
+        log.info("Command: %s", " ".join(cmd))
 
-    if result.returncode == 0:
-        log.info("=== TESTS: PASSED ===")
-    else:
-        log.error("=== TESTS: FAILED (exit code %d) ===", result.returncode)
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=test_framework_dir,
+                capture_output=True,
+                text=True,
+                timeout=timeout + 300,  # run-runtime-tests.sh builds wrappers+bridge+app before tests
+            )
 
-    return result.returncode
+            # Print output so it appears in GHA logs
+            if result.stdout:
+                print(result.stdout, end="", flush=True)
+            if result.stderr:
+                print(result.stderr, end="", file=sys.stderr, flush=True)
+
+            if result.returncode == 0:
+                log.info("=== TESTS: PASSED ===")
+                return 0
+
+            # Check if this is a timeout/hang (retryable) vs real test failure
+            output = result.stdout or ""
+            if "RUNTIME TESTS TIMEOUT" in output or "launch_failure" in output:
+                if attempt <= max_test_retries:
+                    log.warning("Tests timed out / app hung — will retry")
+                    continue
+            # Real test failure (assertions, etc.) — don't retry
+            log.error("=== TESTS: FAILED (exit code %d) ===", result.returncode)
+            return result.returncode
+
+        except subprocess.TimeoutExpired as e:
+            # subprocess itself timed out
+            if e.stdout:
+                print(e.stdout if isinstance(e.stdout, str) else e.stdout.decode(), end="", flush=True)
+            if attempt <= max_test_retries:
+                log.warning("Test subprocess timed out — will retry")
+                continue
+            log.error("=== TESTS: TIMED OUT (subprocess) ===")
+            return 1
+
+    return 1  # Should not reach here
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ci/ci_ios_test.py
+++ b/scripts/ci/ci_ios_test.py
@@ -151,15 +151,22 @@ def run_tests(
         cmd.append("--skip-regen")
 
     # First attempt: generous timeout (build + test).
-    # Retry: also needs full build time since we clean corrupted artifacts.
+    # Retry overhead depends on whether the previous build completed.
     FIRST_ATTEMPT_OVERHEAD = 300  # seconds for wrapper+bridge+app build
-    RETRY_OVERHEAD = 300          # full rebuild needed (artifacts cleaned)
+    RETRY_OVERHEAD_CLEAN = 300    # full rebuild if build was interrupted
+    RETRY_OVERHEAD_CACHED = 120   # incremental rebuild if build completed
     APP_BUNDLE_ID = "com.swiftbindings.runtimetestsapp"
+    last_output = ""  # Track output from previous attempt for smart cleanup
 
     for attempt in range(1, max_test_retries + 2):
         if attempt > 1:
+            # Determine if we need a full rebuild or incremental
+            # If "Step 3" appeared in last output, build completed — artifacts are fine
+            build_completed = "Step 3: Run on iOS Simulator" in last_output
+            retry_overhead = RETRY_OVERHEAD_CACHED if build_completed else RETRY_OVERHEAD_CLEAN
+
             # Check if we have enough time for a retry
-            min_retry_time = timeout + RETRY_OVERHEAD
+            min_retry_time = timeout + retry_overhead
             if deadline is not None:
                 remaining = deadline - time.time()
                 if remaining < min_retry_time:
@@ -170,24 +177,22 @@ def run_tests(
                     return 1
                 log.info("%.0fs remaining — enough for retry (need %ds)", remaining, min_retry_time)
 
-            # Clean up after previous attempt to prevent stale state:
-            # 1. Terminate any lingering app to avoid launch_failure
-            # 2. Clean build artifacts to avoid corrupted AOT .o files
-            #    (subprocess kill can interrupt dotnet build mid-compilation)
-            log.info("Cleaning up before retry...")
+            # Clean up after previous attempt to prevent stale state
+            log.info("Cleaning up before retry (build_completed=%s)...", build_completed)
             try:
                 mgr = SimManager()
                 mgr.terminate_app(device_udid, APP_BUNDLE_ID)
             except Exception:
                 pass  # App may not be running — that's fine
 
-            # Clean corrupted build artifacts from killed subprocess
-            app_dir = os.path.join(test_framework_dir, "RuntimeTestsApp")
-            for subdir in ("obj", "bin"):
-                path = os.path.join(app_dir, subdir)
-                if os.path.isdir(path):
-                    log.info("Cleaning %s", path)
-                    shutil.rmtree(path, ignore_errors=True)
+            if not build_completed:
+                # Build was interrupted — clean corrupted AOT artifacts
+                app_dir = os.path.join(test_framework_dir, "RuntimeTestsApp")
+                for subdir in ("obj", "bin"):
+                    path = os.path.join(app_dir, subdir)
+                    if os.path.isdir(path):
+                        log.info("Cleaning corrupted build artifacts: %s", path)
+                        shutil.rmtree(path, ignore_errors=True)
 
             time.sleep(2)  # Let simulator settle
 
@@ -195,7 +200,10 @@ def run_tests(
             gha_warning(f"Test retry attempt {attempt} after timeout/hang")
 
         # Calculate subprocess timeout
-        overhead = FIRST_ATTEMPT_OVERHEAD if attempt == 1 else RETRY_OVERHEAD
+        if attempt == 1:
+            overhead = FIRST_ATTEMPT_OVERHEAD
+        else:
+            overhead = RETRY_OVERHEAD_CLEAN if not build_completed else RETRY_OVERHEAD_CACHED
         if deadline is not None:
             remaining = deadline - time.time()
             # Use the lesser of our standard timeout and remaining time (minus 30s safety margin)
@@ -217,6 +225,7 @@ def run_tests(
             )
 
             # Print output so it appears in GHA logs
+            last_output = result.stdout or ""
             if result.stdout:
                 print(result.stdout, end="", flush=True)
             if result.stderr:
@@ -227,8 +236,7 @@ def run_tests(
                 return 0
 
             # Check if this is a timeout/hang (retryable) vs real test failure
-            output = result.stdout or ""
-            if "RUNTIME TESTS TIMEOUT" in output or "launch_failure" in output:
+            if "RUNTIME TESTS TIMEOUT" in last_output or "launch_failure" in last_output:
                 if attempt <= max_test_retries:
                     log.warning("Tests timed out / app hung — will retry")
                     continue
@@ -237,9 +245,12 @@ def run_tests(
             return result.returncode
 
         except subprocess.TimeoutExpired as e:
-            # subprocess itself timed out
+            # subprocess itself timed out — capture output for smart cleanup
             if e.stdout:
-                print(e.stdout if isinstance(e.stdout, str) else e.stdout.decode(), end="", flush=True)
+                last_output = e.stdout if isinstance(e.stdout, str) else e.stdout.decode()
+                print(last_output, end="", flush=True)
+            else:
+                last_output = ""
             if attempt <= max_test_retries:
                 log.warning("Test subprocess timed out — will retry")
                 continue
@@ -527,8 +538,8 @@ Examples:
                                  help="Max infrastructure retries (default: 1)")
     resilience_group.add_argument("--diag-dir", default="/tmp/sim-diagnostics",
                                  help="Directory for diagnostic artifacts")
-    resilience_group.add_argument("--step-timeout", type=int, default=900,
-                                 help="Total wall-clock budget in seconds (default: 900 = 15 min)")
+    resilience_group.add_argument("--step-timeout", type=int, default=1140,
+                                 help="Total wall-clock budget in seconds (default: 1140 = 19 min)")
 
     # Logging
     parser.add_argument("-v", "--verbose", action="store_true", help="Debug logging")

--- a/scripts/ci/ci_ios_test.py
+++ b/scripts/ci/ci_ios_test.py
@@ -29,6 +29,7 @@ Usage:
 import argparse
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -150,9 +151,9 @@ def run_tests(
         cmd.append("--skip-regen")
 
     # First attempt: generous timeout (build + test).
-    # Retry: much shorter — app is already built/cached, only needs test time.
+    # Retry: also needs full build time since we clean corrupted artifacts.
     FIRST_ATTEMPT_OVERHEAD = 300  # seconds for wrapper+bridge+app build
-    RETRY_OVERHEAD = 120          # cached build is much faster
+    RETRY_OVERHEAD = 300          # full rebuild needed (artifacts cleaned)
     APP_BUNDLE_ID = "com.swiftbindings.runtimetestsapp"
 
     for attempt in range(1, max_test_retries + 2):
@@ -169,14 +170,26 @@ def run_tests(
                     return 1
                 log.info("%.0fs remaining — enough for retry (need %ds)", remaining, min_retry_time)
 
-            # Terminate any lingering app from previous attempt to avoid launch_failure
-            log.info("Terminating lingering app before retry...")
+            # Clean up after previous attempt to prevent stale state:
+            # 1. Terminate any lingering app to avoid launch_failure
+            # 2. Clean build artifacts to avoid corrupted AOT .o files
+            #    (subprocess kill can interrupt dotnet build mid-compilation)
+            log.info("Cleaning up before retry...")
             try:
                 mgr = SimManager()
                 mgr.terminate_app(device_udid, APP_BUNDLE_ID)
-                time.sleep(2)  # Let simulator settle
             except Exception:
                 pass  # App may not be running — that's fine
+
+            # Clean corrupted build artifacts from killed subprocess
+            app_dir = os.path.join(test_framework_dir, "RuntimeTestsApp")
+            for subdir in ("obj", "bin"):
+                path = os.path.join(app_dir, subdir)
+                if os.path.isdir(path):
+                    log.info("Cleaning %s", path)
+                    shutil.rmtree(path, ignore_errors=True)
+
+            time.sleep(2)  # Let simulator settle
 
             log.info("=== TESTS: Retry attempt %d (previous run timed out) ===", attempt)
             gha_warning(f"Test retry attempt {attempt} after timeout/hang")

--- a/scripts/ci/ci_ios_test.py
+++ b/scripts/ci/ci_ios_test.py
@@ -145,7 +145,7 @@ def run_tests(
     result = subprocess.run(
         cmd,
         cwd=test_framework_dir,
-        timeout=timeout + 60,  # Extra margin beyond test timeout
+        timeout=timeout + 300,  # run-runtime-tests.sh builds wrappers+bridge+app before tests
     )
 
     if result.returncode == 0:

--- a/scripts/ci/ci_ios_test.py
+++ b/scripts/ci/ci_ios_test.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Justin Wojciechowski.
+# Licensed under the MIT License.
+
+"""
+CI orchestrator for iOS Simulator tests.
+
+Manages the full lifecycle: simulator creation, parallel boot + build,
+test execution, diagnostics collection, and cleanup. Designed to replace
+inline bash/YAML in GitHub Actions workflows.
+
+Usage:
+    # Full pipeline (create fresh sim, parallel boot+build, test, cleanup)
+    python3 ci_ios_test.py
+
+    # Use existing device
+    python3 ci_ios_test.py --reuse-device
+
+    # With specific runtime
+    python3 ci_ios_test.py --runtime iOS-18
+
+    # Just prepare sim + output UDID (for multi-step workflows)
+    python3 ci_ios_test.py --prepare-only
+
+    # Just run tests with pre-booted sim
+    python3 ci_ios_test.py --device-udid <UDID> --skip-prepare
+"""
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, Future
+from pathlib import Path
+from typing import Optional
+
+# Add parent directory so we can import sim_manager
+sys.path.insert(0, str(Path(__file__).parent))
+from sim_manager import (
+    SimManager, SimConfig, SimError,
+    SimulatorBootTimeout, SimulatorReadinessTimeout, SimulatorNotFound,
+)
+
+log = logging.getLogger("ci_ios_test")
+
+# ---------------------------------------------------------------------------
+# Error classification
+# ---------------------------------------------------------------------------
+
+# Patterns in stderr/output that indicate infrastructure (retryable) failures
+INFRA_FAILURE_PATTERNS = [
+    "failed to boot",
+    "unable to boot",
+    "unable to lookup in current state",
+    "CoreSimulatorService connection interrupted",
+    "timed out waiting",
+    "launchd",
+    "bootstrap",
+    "SimulatorBootTimeout",
+    "SimulatorReadinessTimeout",
+    "domain error",
+    "Unable to negotiate with CoreSimulatorService",
+]
+
+
+def is_infra_failure(error: Exception) -> bool:
+    """Classify whether an error is retryable infrastructure vs real test failure."""
+    if isinstance(error, (SimulatorBootTimeout, SimulatorReadinessTimeout, SimulatorNotFound)):
+        return True
+    msg = str(error).lower()
+    return any(pat.lower() in msg for pat in INFRA_FAILURE_PATTERNS)
+
+
+# ---------------------------------------------------------------------------
+# Build step
+# ---------------------------------------------------------------------------
+
+def run_build(test_framework_dir: str, skip_regen: bool = True) -> None:
+    """Run the TestFramework build steps.
+
+    When used in the full CI pipeline, build-and-test.sh has already run
+    by this point. We just need to ensure the RuntimeTestsApp is built.
+    """
+    log.info("=== BUILD: Starting dotnet build ===")
+    app_dir = os.path.join(test_framework_dir, "RuntimeTestsApp")
+
+    result = subprocess.run(
+        ["dotnet", "build", "-c", "Debug"],
+        cwd=app_dir,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+    if result.returncode != 0:
+        log.error("Build failed:\n%s", result.stderr[-2000:] if result.stderr else result.stdout[-2000:])
+        raise RuntimeError(f"dotnet build failed with exit code {result.returncode}")
+
+    # Verify app bundle exists
+    app_bundle = os.path.join(
+        app_dir, "bin", "Debug", "net10.0-ios", "iossimulator-arm64", "RuntimeTestsApp.app"
+    )
+    if not os.path.isdir(app_bundle):
+        raise RuntimeError(f"App bundle not found at {app_bundle}")
+
+    log.info("=== BUILD: Success ===")
+
+
+# ---------------------------------------------------------------------------
+# Test execution
+# ---------------------------------------------------------------------------
+
+def run_tests(
+    test_framework_dir: str,
+    device_udid: str,
+    tier: int = 2,
+    timeout: int = 90,
+    safe_only: bool = True,
+    skip_regen: bool = True,
+) -> int:
+    """Run runtime tests using the existing run-runtime-tests.sh script.
+
+    We delegate to the existing script to preserve all the nuanced crash
+    detection, Mono JIT tolerance, and result classification logic.
+
+    Returns:
+        Exit code from run-runtime-tests.sh
+    """
+    cmd = [
+        "./run-runtime-tests.sh",
+        "--tier", str(tier),
+        "--timeout", str(timeout),
+        "--device-udid", device_udid,
+    ]
+    if safe_only:
+        cmd.append("--safe-only")
+    if skip_regen:
+        cmd.append("--skip-regen")
+
+    log.info("=== TESTS: Running runtime tests (tier=%d, timeout=%ds) ===", tier, timeout)
+    log.info("Command: %s", " ".join(cmd))
+
+    result = subprocess.run(
+        cmd,
+        cwd=test_framework_dir,
+        timeout=timeout + 60,  # Extra margin beyond test timeout
+    )
+
+    if result.returncode == 0:
+        log.info("=== TESTS: PASSED ===")
+    else:
+        log.error("=== TESTS: FAILED (exit code %d) ===", result.returncode)
+
+    return result.returncode
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions helpers
+# ---------------------------------------------------------------------------
+
+def set_gha_output(name: str, value: str) -> None:
+    """Set a GitHub Actions output variable."""
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{name}={value}\n")
+        log.info("Set GHA output: %s=%s", name, value)
+    else:
+        log.debug("Not in GHA environment, skipping output: %s=%s", name, value)
+
+
+def set_gha_env(name: str, value: str) -> None:
+    """Set a GitHub Actions environment variable for subsequent steps."""
+    env_file = os.environ.get("GITHUB_ENV")
+    if env_file:
+        with open(env_file, "a") as f:
+            f.write(f"{name}={value}\n")
+
+
+def gha_group(title: str) -> None:
+    """Start a GitHub Actions log group."""
+    if os.environ.get("GITHUB_ACTIONS"):
+        print(f"::group::{title}", flush=True)
+
+
+def gha_endgroup() -> None:
+    """End a GitHub Actions log group."""
+    if os.environ.get("GITHUB_ACTIONS"):
+        print("::endgroup::", flush=True)
+
+
+def gha_error(message: str) -> None:
+    """Emit a GitHub Actions error annotation."""
+    if os.environ.get("GITHUB_ACTIONS"):
+        print(f"::error::{message}", flush=True)
+
+
+def gha_warning(message: str) -> None:
+    """Emit a GitHub Actions warning annotation."""
+    if os.environ.get("GITHUB_ACTIONS"):
+        print(f"::warning::{message}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+def run_pipeline(
+    test_framework_dir: str,
+    runtime_prefix: Optional[str] = None,
+    device_name: Optional[str] = None,
+    device_udid: Optional[str] = None,
+    create_fresh: bool = True,
+    prepare_only: bool = False,
+    skip_prepare: bool = False,
+    skip_build: bool = False,
+    tier: int = 2,
+    test_timeout: int = 90,
+    safe_only: bool = True,
+    skip_regen: bool = True,
+    max_infra_retries: int = 1,
+    diag_dir: str = "/tmp/sim-diagnostics",
+) -> int:
+    """Full CI pipeline: prepare simulator, build, test, cleanup.
+
+    Returns:
+        0 on success, non-zero on failure.
+    """
+    mgr = SimManager()
+    created_udid = None  # Track what we created for cleanup
+
+    for attempt in range(1, max_infra_retries + 2):  # +2 because range is exclusive and attempt 1 is first try
+        try:
+            if attempt > 1:
+                log.info("")
+                log.info("=" * 60)
+                log.info("RETRY attempt %d/%d (infrastructure failure)", attempt, max_infra_retries + 1)
+                log.info("=" * 60)
+
+            # Phase 1: Prepare simulator (parallel with build)
+            if not skip_prepare and not device_udid:
+                if skip_build:
+                    # Sequential: just prepare the simulator
+                    gha_group("Prepare iOS Simulator")
+                    log.info("=== PREPARE: Creating and booting simulator ===")
+                    created_udid = mgr.prepare_simulator(
+                        runtime_prefix, device_name,
+                        create_fresh=create_fresh,
+                    )
+                    device_udid = created_udid
+                    gha_endgroup()
+                else:
+                    # Parallel: boot simulator + build simultaneously
+                    gha_group("Parallel: Boot Simulator + Build")
+                    log.info("=== PARALLEL: Starting simulator boot + dotnet build ===")
+
+                    with ThreadPoolExecutor(max_workers=2) as executor:
+                        sim_future: Future = executor.submit(
+                            mgr.prepare_simulator,
+                            runtime_prefix, device_name,
+                            create_fresh,
+                        )
+                        build_future: Future = executor.submit(
+                            run_build, test_framework_dir, skip_regen,
+                        )
+
+                        # Wait for both, collect errors
+                        errors = []
+                        for name, future in [("simulator", sim_future), ("build", build_future)]:
+                            try:
+                                result = future.result(timeout=360)
+                                if name == "simulator":
+                                    created_udid = result
+                                    device_udid = result
+                                    log.info("Simulator ready: %s", device_udid)
+                            except Exception as e:
+                                log.error("%s failed: %s", name, e)
+                                errors.append((name, e))
+
+                        if errors:
+                            # If simulator failed, raise that (possibly retryable)
+                            for name, err in errors:
+                                if name == "simulator":
+                                    raise err
+                            # Otherwise build failed (not retryable)
+                            _, err = errors[0]
+                            raise err
+
+                    gha_endgroup()
+                    skip_build = True  # Don't rebuild on retry
+
+                set_gha_output("device_udid", device_udid)
+                set_gha_env("SIM_UDID", device_udid)
+                log.info("Simulator UDID: %s", device_udid)
+
+            elif device_udid:
+                log.info("Using provided simulator: %s", device_udid)
+
+            if prepare_only:
+                log.info("=== PREPARE-ONLY: Simulator ready, exiting ===")
+                print(device_udid)
+                return 0
+
+            # Phase 2: Build (if not already done in parallel)
+            if not skip_build:
+                gha_group("Build RuntimeTestsApp")
+                run_build(test_framework_dir, skip_regen)
+                gha_endgroup()
+                skip_build = True
+
+            # Phase 3: Run tests
+            gha_group("Run iOS Simulator Tests")
+            exit_code = run_tests(
+                test_framework_dir,
+                device_udid,
+                tier=tier,
+                timeout=test_timeout,
+                safe_only=safe_only,
+                skip_regen=skip_regen,
+            )
+            gha_endgroup()
+
+            if exit_code == 0:
+                return 0
+
+            # Test failed — but is it infra or real?
+            # For now, test failures from run-runtime-tests.sh are considered real
+            # (that script already handles Mono JIT tolerance internally)
+            return exit_code
+
+        except Exception as e:
+            log.error("Pipeline error: %s", e)
+
+            if is_infra_failure(e) and attempt <= max_infra_retries:
+                gha_warning(f"Infrastructure failure (attempt {attempt}): {e}")
+                log.info("Collecting diagnostics before retry...")
+                if created_udid:
+                    try:
+                        mgr.collect_diagnostics(created_udid, diag_dir)
+                    except Exception as diag_err:
+                        log.warning("Diagnostics collection failed: %s", diag_err)
+                    mgr.cleanup(created_udid)
+                    created_udid = None
+                    device_udid = None
+                continue
+
+            # Non-retryable or out of retries
+            gha_error(f"Pipeline failed: {e}")
+            if created_udid:
+                log.info("Collecting diagnostics...")
+                try:
+                    mgr.collect_diagnostics(created_udid, diag_dir)
+                except Exception as diag_err:
+                    log.warning("Diagnostics collection failed: %s", diag_err)
+            return 1
+
+        finally:
+            # Cleanup on the last attempt or on success
+            # (Don't cleanup on retry — we do it explicitly above)
+            if attempt > max_infra_retries or not is_infra_failure(sys.exc_info()[1] or Exception()):
+                if created_udid:
+                    gha_group("Cleanup Simulator")
+                    mgr.cleanup(created_udid)
+                    gha_endgroup()
+
+    return 1  # Should not reach here
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="CI orchestrator for iOS Simulator tests",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Full pipeline (parallel boot+build, test, cleanup)
+  python3 ci_ios_test.py --test-framework-dir TestFramework
+
+  # Just prepare simulator and output UDID
+  python3 ci_ios_test.py --prepare-only
+
+  # Run tests with pre-booted simulator
+  python3 ci_ios_test.py --device-udid ABC123 --skip-prepare
+
+  # Use existing device instead of creating fresh
+  python3 ci_ios_test.py --reuse-device
+""",
+    )
+
+    # Simulator options
+    sim_group = parser.add_argument_group("simulator")
+    sim_group.add_argument("--runtime", help="iOS runtime prefix (e.g. iOS-18)")
+    sim_group.add_argument("--device-type", help="Device name (e.g. 'iPhone 16')")
+    sim_group.add_argument("--device-udid", help="Use pre-booted simulator UDID")
+    sim_group.add_argument("--reuse-device", action="store_true",
+                          help="Reuse existing device instead of creating fresh")
+    sim_group.add_argument("--prepare-only", action="store_true",
+                          help="Only prepare simulator, print UDID, and exit")
+    sim_group.add_argument("--skip-prepare", action="store_true",
+                          help="Skip simulator preparation (requires --device-udid)")
+
+    # Build/test options
+    test_group = parser.add_argument_group("test")
+    test_group.add_argument("--test-framework-dir", default="TestFramework",
+                           help="Path to TestFramework directory (default: TestFramework)")
+    test_group.add_argument("--tier", type=int, default=2, help="Test tier (default: 2)")
+    test_group.add_argument("--timeout", type=int, default=90, help="Test timeout in seconds (default: 90)")
+    test_group.add_argument("--safe-only", action="store_true", default=True,
+                           help="Skip [CrashRisk] classes (default: true)")
+    test_group.add_argument("--no-safe-only", action="store_false", dest="safe_only",
+                           help="Include [CrashRisk] classes")
+    test_group.add_argument("--skip-regen", action="store_true", default=True,
+                           help="Skip binding regeneration (default: true)")
+    test_group.add_argument("--skip-build", action="store_true",
+                           help="Skip dotnet build (app already built)")
+
+    # Resilience options
+    resilience_group = parser.add_argument_group("resilience")
+    resilience_group.add_argument("--max-retries", type=int, default=1,
+                                 help="Max infrastructure retries (default: 1)")
+    resilience_group.add_argument("--diag-dir", default="/tmp/sim-diagnostics",
+                                 help="Directory for diagnostic artifacts")
+
+    # Logging
+    parser.add_argument("-v", "--verbose", action="store_true", help="Debug logging")
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    if args.skip_prepare and not args.device_udid:
+        parser.error("--skip-prepare requires --device-udid")
+
+    # Resolve test framework directory relative to repo root
+    tf_dir = args.test_framework_dir
+    if not os.path.isabs(tf_dir):
+        # If running from repo root, TestFramework is a subdirectory
+        # If running from .github/workflows context, adjust
+        if not os.path.isdir(tf_dir):
+            # Try relative to script location
+            script_dir = Path(__file__).parent
+            repo_root = script_dir.parent.parent
+            tf_dir = str(repo_root / tf_dir)
+
+    if not os.path.isdir(tf_dir):
+        log.error("TestFramework directory not found: %s", tf_dir)
+        sys.exit(1)
+
+    exit_code = run_pipeline(
+        test_framework_dir=tf_dir,
+        runtime_prefix=args.runtime,
+        device_name=args.device_type,
+        device_udid=args.device_udid,
+        create_fresh=not args.reuse_device,
+        prepare_only=args.prepare_only,
+        skip_prepare=args.skip_prepare,
+        skip_build=args.skip_build,
+        tier=args.tier,
+        test_timeout=args.timeout,
+        safe_only=args.safe_only,
+        skip_regen=args.skip_regen,
+        max_infra_retries=args.max_retries,
+        diag_dir=args.diag_dir,
+    )
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/ci_ios_test.py
+++ b/scripts/ci/ci_ios_test.py
@@ -120,13 +120,20 @@ def run_tests(
     safe_only: bool = True,
     skip_regen: bool = True,
     max_test_retries: int = 1,
+    deadline: Optional[float] = None,
 ) -> int:
     """Run runtime tests using the existing run-runtime-tests.sh script.
 
     We delegate to the existing script to preserve all the nuanced crash
     detection, Mono JIT tolerance, and result classification logic.
 
-    Retries once on timeout/infrastructure failure (app hang, launch failure).
+    Retries once on timeout/infrastructure failure (app hang, launch failure),
+    but only if enough time remains before the deadline.
+
+    Args:
+        deadline: Absolute time.time() by which we must finish. Used to
+                  skip retries that can't complete and to shrink subprocess
+                  timeouts on later attempts.
 
     Returns:
         Exit code from run-runtime-tests.sh
@@ -142,13 +149,39 @@ def run_tests(
     if skip_regen:
         cmd.append("--skip-regen")
 
+    # First attempt: generous timeout (build + test).
+    # Retry: much shorter — app is already built/cached, only needs test time.
+    FIRST_ATTEMPT_OVERHEAD = 300  # seconds for wrapper+bridge+app build
+    RETRY_OVERHEAD = 120          # cached build is much faster
+
     for attempt in range(1, max_test_retries + 2):
         if attempt > 1:
+            # Check if we have enough time for a retry
+            min_retry_time = timeout + RETRY_OVERHEAD
+            if deadline is not None:
+                remaining = deadline - time.time()
+                if remaining < min_retry_time:
+                    log.warning(
+                        "Only %.0fs remaining (need %ds for retry) — skipping retry",
+                        remaining, min_retry_time,
+                    )
+                    return 1
+                log.info("%.0fs remaining — enough for retry (need %ds)", remaining, min_retry_time)
+
             log.info("=== TESTS: Retry attempt %d (previous run timed out) ===", attempt)
             gha_warning(f"Test retry attempt {attempt} after timeout/hang")
 
-        log.info("=== TESTS: Running runtime tests (tier=%d, timeout=%ds, attempt=%d) ===",
-                 tier, timeout, attempt)
+        # Calculate subprocess timeout
+        overhead = FIRST_ATTEMPT_OVERHEAD if attempt == 1 else RETRY_OVERHEAD
+        if deadline is not None:
+            remaining = deadline - time.time()
+            # Use the lesser of our standard timeout and remaining time (minus 30s safety margin)
+            subprocess_timeout = min(timeout + overhead, max(remaining - 30, timeout + 60))
+        else:
+            subprocess_timeout = timeout + overhead
+
+        log.info("=== TESTS: Running runtime tests (tier=%d, timeout=%ds, attempt=%d, subprocess_timeout=%.0fs) ===",
+                 tier, timeout, attempt, subprocess_timeout)
         log.info("Command: %s", " ".join(cmd))
 
         try:
@@ -157,7 +190,7 @@ def run_tests(
                 cwd=test_framework_dir,
                 capture_output=True,
                 text=True,
-                timeout=timeout + 300,  # run-runtime-tests.sh builds wrappers+bridge+app before tests
+                timeout=subprocess_timeout,
             )
 
             # Print output so it appears in GHA logs
@@ -259,12 +292,20 @@ def run_pipeline(
     skip_regen: bool = True,
     max_infra_retries: int = 1,
     diag_dir: str = "/tmp/sim-diagnostics",
+    step_timeout: int = 900,
 ) -> int:
     """Full CI pipeline: prepare simulator, build, test, cleanup.
+
+    Args:
+        step_timeout: Total wall-clock budget in seconds (matches the GHA
+                      timeout-minutes value). Used to compute a deadline so
+                      retries are skipped when insufficient time remains.
 
     Returns:
         0 on success, non-zero on failure.
     """
+    pipeline_start = time.time()
+    deadline = pipeline_start + step_timeout  # absolute time we must finish by
     mgr = SimManager()
     created_udid = None  # Track what we created for cleanup
 
@@ -356,6 +397,7 @@ def run_pipeline(
                 timeout=test_timeout,
                 safe_only=safe_only,
                 skip_regen=skip_regen,
+                deadline=deadline,
             )
             gha_endgroup()
 
@@ -462,6 +504,8 @@ Examples:
                                  help="Max infrastructure retries (default: 1)")
     resilience_group.add_argument("--diag-dir", default="/tmp/sim-diagnostics",
                                  help="Directory for diagnostic artifacts")
+    resilience_group.add_argument("--step-timeout", type=int, default=900,
+                                 help="Total wall-clock budget in seconds (default: 900 = 15 min)")
 
     # Logging
     parser.add_argument("-v", "--verbose", action="store_true", help="Debug logging")
@@ -507,6 +551,7 @@ Examples:
         skip_regen=args.skip_regen,
         max_infra_retries=args.max_retries,
         diag_dir=args.diag_dir,
+        step_timeout=args.step_timeout,
     )
     sys.exit(exit_code)
 

--- a/scripts/ci/ci_ios_test.py
+++ b/scripts/ci/ci_ios_test.py
@@ -153,6 +153,7 @@ def run_tests(
     # Retry: much shorter — app is already built/cached, only needs test time.
     FIRST_ATTEMPT_OVERHEAD = 300  # seconds for wrapper+bridge+app build
     RETRY_OVERHEAD = 120          # cached build is much faster
+    APP_BUNDLE_ID = "com.swiftbindings.runtimetestsapp"
 
     for attempt in range(1, max_test_retries + 2):
         if attempt > 1:
@@ -167,6 +168,15 @@ def run_tests(
                     )
                     return 1
                 log.info("%.0fs remaining — enough for retry (need %ds)", remaining, min_retry_time)
+
+            # Terminate any lingering app from previous attempt to avoid launch_failure
+            log.info("Terminating lingering app before retry...")
+            try:
+                mgr = SimManager()
+                mgr.terminate_app(device_udid, APP_BUNDLE_ID)
+                time.sleep(2)  # Let simulator settle
+            except Exception:
+                pass  # App may not be running — that's fine
 
             log.info("=== TESTS: Retry attempt %d (previous run timed out) ===", attempt)
             gha_warning(f"Test retry attempt {attempt} after timeout/hang")

--- a/scripts/ci/sim_manager.py
+++ b/scripts/ci/sim_manager.py
@@ -95,8 +95,8 @@ class SimConfig:
 
     # Readiness probe settings (phase 2 after Booted)
     readiness_poll_interval: float = 2.0
-    readiness_timeout: float = 60.0
-    readiness_probe_timeout: float = 10.0  # per-probe command timeout
+    readiness_timeout: float = 120.0       # GHA runners can be very slow
+    readiness_probe_timeout: float = 30.0  # per-probe timeout (GHA simctl spawn is slow)
 
     # Preferred device types (in order)
     preferred_devices: list = field(default_factory=lambda: [

--- a/scripts/ci/sim_manager.py
+++ b/scripts/ci/sim_manager.py
@@ -87,7 +87,7 @@ class SimConfig:
     command_max_retries: int = 3
     command_backoff_base: float = 2.0      # seconds
     command_backoff_max: float = 8.0       # seconds
-    command_timeout: float = 30.0          # per-command timeout
+    command_timeout: float = 60.0          # per-command timeout (GHA simctl can be slow)
 
     # Boot phase settings
     boot_poll_interval: float = 3.0        # seconds between state polls

--- a/scripts/ci/sim_manager.py
+++ b/scripts/ci/sim_manager.py
@@ -1,0 +1,687 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Justin Wojciechowski.
+# Licensed under the MIT License.
+
+"""
+iOS Simulator lifecycle manager for CI environments.
+
+Provides reliable simulator creation, boot, readiness detection, and cleanup
+with retry logic and structured diagnostics. Designed for GitHub Actions macOS
+runners where `xcrun simctl bootstatus -b` hangs.
+
+Usage (standalone):
+    python3 sim_manager.py create --runtime iOS-18 --device-type iPhone-16
+    python3 sim_manager.py boot <udid>
+    python3 sim_manager.py wait-ready <udid>
+    python3 sim_manager.py cleanup <udid>
+    python3 sim_manager.py diagnose <udid> --output-dir /tmp/sim-diag
+
+Usage (as module):
+    from sim_manager import SimManager
+    mgr = SimManager()
+    udid = mgr.create_simulator("iOS-18", "iPhone-16")
+    mgr.boot_and_wait(udid)
+    # ... run tests ...
+    mgr.cleanup(udid)
+"""
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("sim_manager")
+
+
+# ---------------------------------------------------------------------------
+# Error hierarchy
+# ---------------------------------------------------------------------------
+
+class SimError(Exception):
+    """Base error for simulator operations."""
+    pass
+
+class SimctlCommandError(SimError):
+    """A simctl command failed after retries."""
+    def __init__(self, cmd, returncode, stderr):
+        self.cmd = cmd
+        self.returncode = returncode
+        self.stderr = stderr
+        super().__init__(f"simctl {' '.join(cmd)} failed (rc={returncode}): {stderr}")
+
+class SimulatorBootTimeout(SimError):
+    """Simulator did not reach Booted state in time."""
+    pass
+
+class SimulatorReadinessTimeout(SimError):
+    """Simulator booted but did not become responsive."""
+    pass
+
+class SimulatorNotFound(SimError):
+    """No matching simulator runtime or device type found."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+class DeviceState(str, Enum):
+    SHUTDOWN = "Shutdown"
+    BOOTED = "Booted"
+    SHUTTING_DOWN = "Shutting Down"
+    CREATING = "Creating"
+
+
+@dataclass
+class SimConfig:
+    """Tunable parameters for simulator lifecycle."""
+    # Retry settings for individual simctl commands
+    command_max_retries: int = 3
+    command_backoff_base: float = 2.0      # seconds
+    command_backoff_max: float = 8.0       # seconds
+    command_timeout: float = 30.0          # per-command timeout
+
+    # Boot phase settings
+    boot_poll_interval: float = 3.0        # seconds between state polls
+    boot_timeout: float = 180.0            # max seconds to wait for Booted
+
+    # Readiness probe settings (phase 2 after Booted)
+    readiness_poll_interval: float = 2.0
+    readiness_timeout: float = 60.0
+    readiness_probe_timeout: float = 10.0  # per-probe command timeout
+
+    # Preferred device types (in order)
+    preferred_devices: list = field(default_factory=lambda: [
+        "iPhone 16", "iPhone 17 Pro", "iPhone 15 Pro", "iPhone 15"
+    ])
+
+    # Preferred iOS runtimes (prefix match, newest first)
+    preferred_runtimes: list = field(default_factory=lambda: [
+        "iOS-19", "iOS-18", "iOS-17"
+    ])
+
+
+# ---------------------------------------------------------------------------
+# SimManager
+# ---------------------------------------------------------------------------
+
+class SimManager:
+    """Manages iOS Simulator lifecycle with retries and diagnostics."""
+
+    def __init__(self, config: Optional[SimConfig] = None):
+        self.config = config or SimConfig()
+
+    # -------------------------------------------------------------------
+    # Low-level simctl wrapper with retries
+    # -------------------------------------------------------------------
+
+    def _run_simctl(
+        self,
+        args: list[str],
+        *,
+        check: bool = True,
+        retries: Optional[int] = None,
+        timeout: Optional[float] = None,
+        capture: bool = True,
+    ) -> subprocess.CompletedProcess:
+        """Run an xcrun simctl command with retry and timeout."""
+        max_retries = retries if retries is not None else self.config.command_max_retries
+        cmd_timeout = timeout if timeout is not None else self.config.command_timeout
+        full_cmd = ["xcrun", "simctl"] + args
+        last_err = None
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                log.debug("simctl attempt %d/%d: %s", attempt, max_retries, " ".join(full_cmd))
+                result = subprocess.run(
+                    full_cmd,
+                    capture_output=capture,
+                    text=True,
+                    timeout=cmd_timeout,
+                )
+                if check and result.returncode != 0:
+                    raise SimctlCommandError(args, result.returncode, result.stderr.strip())
+                return result
+            except subprocess.TimeoutExpired:
+                last_err = SimctlCommandError(args, -1, f"timed out after {cmd_timeout}s")
+                log.warning("simctl %s timed out (attempt %d/%d)", args[0], attempt, max_retries)
+            except SimctlCommandError as e:
+                last_err = e
+                log.warning("simctl %s failed (attempt %d/%d): %s", args[0], attempt, max_retries, e.stderr)
+
+            if attempt < max_retries:
+                backoff = min(
+                    self.config.command_backoff_base ** attempt,
+                    self.config.command_backoff_max,
+                )
+                log.info("Retrying in %.1fs...", backoff)
+                time.sleep(backoff)
+
+        raise last_err
+
+    # -------------------------------------------------------------------
+    # Device discovery
+    # -------------------------------------------------------------------
+
+    def list_devices(self) -> dict:
+        """Return parsed simctl device list JSON."""
+        result = self._run_simctl(["list", "devices", "-j"], retries=2)
+        return json.loads(result.stdout)
+
+    def list_runtimes(self) -> dict:
+        """Return parsed simctl runtime list JSON."""
+        result = self._run_simctl(["list", "runtimes", "-j"], retries=2)
+        return json.loads(result.stdout)
+
+    def find_runtime(self, prefix: Optional[str] = None) -> str:
+        """Find the best available iOS runtime identifier.
+
+        Args:
+            prefix: Runtime prefix like "iOS-18" or "iOS-19". If None, uses
+                    config.preferred_runtimes in order.
+
+        Returns:
+            Full runtime identifier string (e.g. "com.apple.CoreSimulator.SimRuntime.iOS-18-2")
+        """
+        runtimes_data = self.list_runtimes()
+        runtimes = runtimes_data.get("runtimes", [])
+
+        # Filter to available iOS runtimes
+        available = [
+            r for r in runtimes
+            if r.get("isAvailable", False) and "iOS" in r.get("name", "")
+        ]
+
+        if not available:
+            raise SimulatorNotFound("No available iOS runtimes found")
+
+        prefixes = [prefix] if prefix else self.config.preferred_runtimes
+        for pref in prefixes:
+            # Match against identifier (e.g. "com.apple.CoreSimulator.SimRuntime.iOS-18-2")
+            # and name (e.g. "iOS 18.2")
+            normalized = pref.replace("-", " ").replace("iOS ", "iOS-")
+            matches = [
+                r for r in available
+                if pref.replace("-", ".") in r.get("name", "")
+                or pref in r.get("identifier", "")
+            ]
+            if matches:
+                # Sort by version (higher is better) — use identifier as proxy
+                matches.sort(key=lambda r: r.get("identifier", ""), reverse=True)
+                chosen = matches[0]
+                log.info("Selected runtime: %s (%s)", chosen["name"], chosen["identifier"])
+                return chosen["identifier"]
+
+        # Fallback: newest available
+        available.sort(key=lambda r: r.get("identifier", ""), reverse=True)
+        chosen = available[0]
+        log.info("Fallback runtime: %s (%s)", chosen["name"], chosen["identifier"])
+        return chosen["identifier"]
+
+    def find_device_type(self, name: Optional[str] = None) -> str:
+        """Find a device type identifier by name.
+
+        Args:
+            name: Device name like "iPhone 16". If None, returns first preferred match.
+
+        Returns:
+            Device type identifier (e.g. "com.apple.CoreSimulator.SimDeviceType.iPhone-16")
+        """
+        result = self._run_simctl(["list", "devicetypes", "-j"], retries=2)
+        device_types = json.loads(result.stdout).get("devicetypes", [])
+
+        names_to_check = [name] if name else self.config.preferred_devices
+        for n in names_to_check:
+            for dt in device_types:
+                if dt.get("name") == n:
+                    log.info("Selected device type: %s (%s)", dt["name"], dt["identifier"])
+                    return dt["identifier"]
+
+        # Fallback: any iPhone
+        for dt in device_types:
+            if "iPhone" in dt.get("name", ""):
+                log.info("Fallback device type: %s (%s)", dt["name"], dt["identifier"])
+                return dt["identifier"]
+
+        raise SimulatorNotFound("No iPhone device type found")
+
+    def find_existing_device(self, runtime_prefix: Optional[str] = None) -> Optional[str]:
+        """Find an existing available iPhone simulator (not booted).
+
+        Returns UDID or None.
+        """
+        devices_data = self.list_devices()
+        for runtime_id, devices in devices_data.get("devices", {}).items():
+            if "iOS" not in runtime_id:
+                continue
+            if runtime_prefix and runtime_prefix not in runtime_id:
+                continue
+            for pref in self.config.preferred_devices:
+                for d in devices:
+                    if (d.get("name") == pref
+                            and d.get("isAvailable", False)
+                            and d.get("state") != DeviceState.BOOTED):
+                        log.info("Found existing device: %s (%s)", d["name"], d["udid"])
+                        return d["udid"]
+            # Fallback: any available iPhone
+            for d in devices:
+                if (d.get("isAvailable", False)
+                        and "iPhone" in d.get("name", "")
+                        and d.get("state") != DeviceState.BOOTED):
+                    log.info("Found existing device (fallback): %s (%s)", d["name"], d["udid"])
+                    return d["udid"]
+        return None
+
+    # -------------------------------------------------------------------
+    # Lifecycle operations
+    # -------------------------------------------------------------------
+
+    def create_simulator(
+        self,
+        runtime_prefix: Optional[str] = None,
+        device_name: Optional[str] = None,
+    ) -> str:
+        """Create a fresh simulator device.
+
+        Args:
+            runtime_prefix: e.g. "iOS-18". Auto-resolves to full identifier.
+            device_name: e.g. "iPhone 16". Auto-resolves to device type.
+
+        Returns:
+            UDID of the created simulator.
+        """
+        runtime_id = self.find_runtime(runtime_prefix)
+        device_type_id = self.find_device_type(device_name)
+
+        # Unique name to avoid collisions on shared runners
+        sim_name = f"ci-sim-{int(time.time())}-{os.getpid()}"
+
+        log.info("Creating simulator: %s (type=%s, runtime=%s)", sim_name, device_type_id, runtime_id)
+        result = self._run_simctl(["create", sim_name, device_type_id, runtime_id])
+        udid = result.stdout.strip()
+        log.info("Created simulator: %s (udid=%s)", sim_name, udid)
+        return udid
+
+    def get_device_state(self, udid: str) -> Optional[str]:
+        """Poll the current state of a device by UDID."""
+        try:
+            devices_data = self.list_devices()
+            for runtime_id, devices in devices_data.get("devices", {}).items():
+                for d in devices:
+                    if d.get("udid") == udid:
+                        return d.get("state")
+        except SimError:
+            return None
+        return None
+
+    def boot(self, udid: str) -> None:
+        """Send the boot command. Does not wait for readiness."""
+        state = self.get_device_state(udid)
+        if state == DeviceState.BOOTED:
+            log.info("Simulator %s already booted", udid)
+            return
+        log.info("Booting simulator %s (current state: %s)...", udid, state)
+        try:
+            self._run_simctl(["boot", udid])
+        except SimctlCommandError as e:
+            # "Unable to boot device in current state: Booted" is fine
+            if "Booted" in str(e.stderr):
+                log.info("Simulator %s was already booting/booted", udid)
+                return
+            raise
+
+    def wait_until_booted(self, udid: str) -> None:
+        """Phase 1: Poll until device state is Booted."""
+        deadline = time.time() + self.config.boot_timeout
+        log.info("Waiting for simulator %s to reach Booted state (timeout: %.0fs)...",
+                 udid, self.config.boot_timeout)
+
+        while time.time() < deadline:
+            state = self.get_device_state(udid)
+            if state == DeviceState.BOOTED:
+                elapsed = self.config.boot_timeout - (deadline - time.time())
+                log.info("Simulator %s reached Booted state in %.1fs", udid, elapsed)
+                return
+            log.debug("Simulator state: %s (%.0fs remaining)", state, deadline - time.time())
+            time.sleep(self.config.boot_poll_interval)
+
+        state = self.get_device_state(udid)
+        raise SimulatorBootTimeout(
+            f"Simulator {udid} did not boot within {self.config.boot_timeout}s "
+            f"(final state: {state})"
+        )
+
+    def wait_until_responsive(self, udid: str) -> None:
+        """Phase 2: Verify simulator is actually responsive after Booted state.
+
+        Uses `simctl spawn` to run a command inside the simulator, confirming
+        the runtime is truly ready (not just reported as Booted).
+        """
+        deadline = time.time() + self.config.readiness_timeout
+        log.info("Probing simulator %s responsiveness (timeout: %.0fs)...",
+                 udid, self.config.readiness_timeout)
+
+        while time.time() < deadline:
+            try:
+                self._run_simctl(
+                    ["spawn", udid, "launchctl", "print", "system"],
+                    retries=1,
+                    timeout=self.config.readiness_probe_timeout,
+                )
+                elapsed = self.config.readiness_timeout - (deadline - time.time())
+                log.info("Simulator %s is responsive (probe succeeded in %.1fs)", udid, elapsed)
+                return
+            except (SimctlCommandError, SimError) as e:
+                log.debug("Readiness probe failed: %s", e)
+                time.sleep(self.config.readiness_poll_interval)
+
+        raise SimulatorReadinessTimeout(
+            f"Simulator {udid} not responsive within {self.config.readiness_timeout}s"
+        )
+
+    def boot_and_wait(self, udid: str) -> None:
+        """Full boot sequence: boot + wait for Booted state + wait for responsiveness."""
+        self.boot(udid)
+        self.wait_until_booted(udid)
+        self.wait_until_responsive(udid)
+
+    def shutdown(self, udid: str) -> None:
+        """Shut down a simulator (best effort)."""
+        try:
+            self._run_simctl(["shutdown", udid], retries=2, timeout=15)
+            log.info("Simulator %s shut down", udid)
+        except SimError as e:
+            log.warning("Shutdown failed (non-fatal): %s", e)
+
+    def delete(self, udid: str) -> None:
+        """Delete a simulator (best effort)."""
+        try:
+            self._run_simctl(["delete", udid], retries=2, timeout=15)
+            log.info("Simulator %s deleted", udid)
+        except SimError as e:
+            log.warning("Delete failed (non-fatal): %s", e)
+
+    def cleanup(self, udid: str) -> None:
+        """Best-effort shutdown + delete. Never raises."""
+        log.info("Cleaning up simulator %s...", udid)
+        try:
+            self.shutdown(udid)
+        except Exception as e:
+            log.warning("Cleanup shutdown failed (non-fatal): %s", e)
+        try:
+            self.delete(udid)
+        except Exception as e:
+            log.warning("Cleanup delete failed (non-fatal): %s", e)
+
+    def erase(self, udid: str) -> None:
+        """Erase simulator contents and settings."""
+        self._run_simctl(["erase", udid])
+        log.info("Simulator %s erased", udid)
+
+    # -------------------------------------------------------------------
+    # App lifecycle (for test execution)
+    # -------------------------------------------------------------------
+
+    def install_app(self, udid: str, app_path: str) -> None:
+        """Install an app bundle on the simulator."""
+        log.info("Installing %s on %s...", app_path, udid)
+        self._run_simctl(["install", udid, app_path], timeout=60)
+
+    def launch_app(
+        self,
+        udid: str,
+        bundle_id: str,
+        args: Optional[list[str]] = None,
+    ) -> subprocess.Popen:
+        """Launch an app and return the Popen handle for output capture.
+
+        Uses --console --terminate-running-process for clean test runs.
+        """
+        cmd = [
+            "xcrun", "simctl", "launch", "--console",
+            "--terminate-running-process", udid, bundle_id,
+        ]
+        if args:
+            cmd.extend(args)
+        log.info("Launching %s on %s with args: %s", bundle_id, udid, args or [])
+        return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+    def terminate_app(self, udid: str, bundle_id: str) -> None:
+        """Terminate a running app (best effort, with timeout)."""
+        try:
+            self._run_simctl(
+                ["terminate", udid, bundle_id],
+                retries=1,
+                timeout=10,
+                check=False,
+            )
+        except SimError:
+            pass
+
+    # -------------------------------------------------------------------
+    # Diagnostics
+    # -------------------------------------------------------------------
+
+    def collect_diagnostics(self, udid: str, output_dir: str) -> list[str]:
+        """Collect diagnostic info for debugging CI failures.
+
+        Returns list of paths to collected diagnostic files.
+        """
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        collected = []
+
+        # 1. Device list snapshot
+        try:
+            result = self._run_simctl(["list", "devices", "-j"], retries=1, timeout=10)
+            devices_file = output_path / "simctl-devices.json"
+            devices_file.write_text(result.stdout)
+            collected.append(str(devices_file))
+            log.info("Saved device list to %s", devices_file)
+        except SimError as e:
+            log.warning("Failed to collect device list: %s", e)
+
+        # 2. Runtime list
+        try:
+            result = self._run_simctl(["list", "runtimes", "-j"], retries=1, timeout=10)
+            runtimes_file = output_path / "simctl-runtimes.json"
+            runtimes_file.write_text(result.stdout)
+            collected.append(str(runtimes_file))
+        except SimError as e:
+            log.warning("Failed to collect runtime list: %s", e)
+
+        # 3. Simulator device log (last 5 minutes)
+        try:
+            result = self._run_simctl(
+                ["spawn", udid, "log", "show", "--last", "5m",
+                 "--predicate",
+                 'process == "RuntimeTestsApp" OR '
+                 '(process == "ReportCrash" AND eventMessage CONTAINS "RuntimeTestsApp")',
+                 "--style", "compact"],
+                retries=1,
+                timeout=30,
+                check=False,
+            )
+            if result.stdout:
+                device_log_file = output_path / "device-log.txt"
+                device_log_file.write_text(result.stdout)
+                collected.append(str(device_log_file))
+                log.info("Saved device log to %s", device_log_file)
+        except SimError as e:
+            log.warning("Failed to collect device log: %s", e)
+
+        # 4. Process snapshot
+        try:
+            result = subprocess.run(
+                ["ps", "aux"],
+                capture_output=True, text=True, timeout=5,
+            )
+            # Filter to simulator-related processes
+            lines = [l for l in result.stdout.splitlines()
+                     if any(k in l.lower() for k in ["simulator", "coresim", "simctl", "runtime"])]
+            if lines:
+                ps_file = output_path / "simulator-processes.txt"
+                ps_file.write_text("\n".join(lines))
+                collected.append(str(ps_file))
+        except Exception as e:
+            log.warning("Failed to collect process list: %s", e)
+
+        # 5. Crash logs
+        crash_dir = Path.home() / "Library" / "Logs" / "DiagnosticReports"
+        try:
+            crash_files = sorted(crash_dir.glob("RuntimeTestsApp*.ips"), key=lambda p: p.stat().st_mtime, reverse=True)
+            for cf in crash_files[:3]:  # Latest 3
+                dest = output_path / cf.name
+                dest.write_bytes(cf.read_bytes())
+                collected.append(str(dest))
+                log.info("Saved crash log: %s", cf.name)
+        except Exception as e:
+            log.warning("Failed to collect crash logs: %s", e)
+
+        # 6. Xcode version
+        try:
+            result = subprocess.run(
+                ["xcodebuild", "-version"],
+                capture_output=True, text=True, timeout=5,
+            )
+            xcode_file = output_path / "xcode-version.txt"
+            xcode_file.write_text(result.stdout)
+            collected.append(str(xcode_file))
+        except Exception:
+            pass
+
+        log.info("Collected %d diagnostic files in %s", len(collected), output_dir)
+        return collected
+
+    # -------------------------------------------------------------------
+    # High-level convenience
+    # -------------------------------------------------------------------
+
+    def prepare_simulator(
+        self,
+        runtime_prefix: Optional[str] = None,
+        device_name: Optional[str] = None,
+        create_fresh: bool = True,
+    ) -> str:
+        """Create (or find) and fully boot a simulator.
+
+        Args:
+            runtime_prefix: e.g. "iOS-18"
+            device_name: e.g. "iPhone 16"
+            create_fresh: If True, always create new. If False, reuse existing.
+
+        Returns:
+            UDID of the ready simulator.
+        """
+        if create_fresh:
+            udid = self.create_simulator(runtime_prefix, device_name)
+        else:
+            udid = self.find_existing_device(runtime_prefix)
+            if not udid:
+                log.info("No existing device found, creating fresh...")
+                udid = self.create_simulator(runtime_prefix, device_name)
+
+        self.boot_and_wait(udid)
+        return udid
+
+
+# ---------------------------------------------------------------------------
+# CLI interface
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="iOS Simulator lifecycle manager for CI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable debug logging")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # create
+    p_create = sub.add_parser("create", help="Create a fresh simulator")
+    p_create.add_argument("--runtime", help="Runtime prefix (e.g. iOS-18)")
+    p_create.add_argument("--device-type", help="Device name (e.g. 'iPhone 16')")
+
+    # boot
+    p_boot = sub.add_parser("boot", help="Boot a simulator by UDID")
+    p_boot.add_argument("udid", help="Simulator UDID")
+
+    # wait-ready
+    p_wait = sub.add_parser("wait-ready", help="Wait for simulator to be fully responsive")
+    p_wait.add_argument("udid", help="Simulator UDID")
+
+    # prepare (create + boot + wait)
+    p_prep = sub.add_parser("prepare", help="Create, boot, and wait for a simulator")
+    p_prep.add_argument("--runtime", help="Runtime prefix (e.g. iOS-18)")
+    p_prep.add_argument("--device-type", help="Device name (e.g. 'iPhone 16')")
+    p_prep.add_argument("--reuse", action="store_true", help="Reuse existing device if available")
+
+    # cleanup
+    p_clean = sub.add_parser("cleanup", help="Shutdown and delete a simulator")
+    p_clean.add_argument("udid", help="Simulator UDID")
+
+    # diagnose
+    p_diag = sub.add_parser("diagnose", help="Collect diagnostic info")
+    p_diag.add_argument("udid", help="Simulator UDID")
+    p_diag.add_argument("--output-dir", default="/tmp/sim-diagnostics", help="Output directory")
+
+    # find
+    p_find = sub.add_parser("find", help="Find an existing available simulator")
+    p_find.add_argument("--runtime", help="Runtime prefix filter")
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    mgr = SimManager()
+
+    if args.command == "create":
+        udid = mgr.create_simulator(args.runtime, args.device_type)
+        print(udid)
+
+    elif args.command == "boot":
+        mgr.boot(args.udid)
+
+    elif args.command == "wait-ready":
+        mgr.wait_until_booted(args.udid)
+        mgr.wait_until_responsive(args.udid)
+
+    elif args.command == "prepare":
+        udid = mgr.prepare_simulator(
+            args.runtime, args.device_type,
+            create_fresh=not args.reuse,
+        )
+        print(udid)
+
+    elif args.command == "cleanup":
+        mgr.cleanup(args.udid)
+
+    elif args.command == "diagnose":
+        files = mgr.collect_diagnostics(args.udid, args.output_dir)
+        for f in files:
+            print(f)
+
+    elif args.command == "find":
+        udid = mgr.find_existing_device(args.runtime)
+        if udid:
+            print(udid)
+        else:
+            log.error("No available simulator found")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test_sim_manager.py
+++ b/scripts/ci/test_sim_manager.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Justin Wojciechowski.
+# Licensed under the MIT License.
+
+"""
+Tests for sim_manager.py — validates simulator lifecycle management.
+
+Run: python3 -m pytest scripts/ci/test_sim_manager.py -v
+  or: python3 scripts/ci/test_sim_manager.py   (direct execution)
+
+Tests are split into:
+  - Unit tests (mocked subprocess, no real simulator needed)
+  - Integration tests (require macOS with Xcode, create real simulators)
+
+Integration tests are marked with @pytest.mark.integration and skipped
+by default. Run with: pytest -m integration
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock, PropertyMock
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent))
+from sim_manager import (
+    SimManager, SimConfig, SimError,
+    SimctlCommandError, SimulatorBootTimeout, SimulatorReadinessTimeout,
+    SimulatorNotFound, DeviceState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (mocked)
+# ---------------------------------------------------------------------------
+
+class TestSimctlRetry(unittest.TestCase):
+    """Test that _run_simctl retries correctly."""
+
+    def test_succeeds_on_first_try(self):
+        mgr = SimManager()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+            result = mgr._run_simctl(["list", "devices"])
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(mock_run.call_count, 1)
+
+    def test_retries_on_failure(self):
+        mgr = SimManager(SimConfig(command_max_retries=3, command_backoff_base=0.01, command_backoff_max=0.02))
+        with patch("subprocess.run") as mock_run:
+            # Fail twice, succeed third time
+            mock_run.side_effect = [
+                MagicMock(returncode=1, stdout="", stderr="error1"),
+                MagicMock(returncode=1, stdout="", stderr="error2"),
+                MagicMock(returncode=0, stdout="ok", stderr=""),
+            ]
+            result = mgr._run_simctl(["boot", "fake-udid"])
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(mock_run.call_count, 3)
+
+    def test_raises_after_max_retries(self):
+        mgr = SimManager(SimConfig(command_max_retries=2, command_backoff_base=0.01, command_backoff_max=0.02))
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="persistent error")
+            with self.assertRaises(SimctlCommandError) as ctx:
+                mgr._run_simctl(["boot", "fake-udid"])
+            self.assertIn("persistent error", str(ctx.exception))
+            self.assertEqual(mock_run.call_count, 2)
+
+    def test_retries_on_timeout(self):
+        mgr = SimManager(SimConfig(command_max_retries=2, command_timeout=0.1, command_backoff_base=0.01))
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.TimeoutExpired(cmd=["xcrun"], timeout=0.1),
+                MagicMock(returncode=0, stdout="ok", stderr=""),
+            ]
+            result = mgr._run_simctl(["list"])
+            self.assertEqual(result.returncode, 0)
+
+    def test_no_retry_when_check_false(self):
+        mgr = SimManager()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+            result = mgr._run_simctl(["terminate", "fake"], check=False)
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(mock_run.call_count, 1)
+
+
+class TestDeviceDiscovery(unittest.TestCase):
+    """Test device/runtime discovery logic."""
+
+    SAMPLE_DEVICES = {
+        "devices": {
+            "com.apple.CoreSimulator.SimRuntime.iOS-18-2": [
+                {"name": "iPhone 15", "udid": "AAA-111", "state": "Shutdown", "isAvailable": True},
+                {"name": "iPhone 16", "udid": "BBB-222", "state": "Shutdown", "isAvailable": True},
+                {"name": "iPad Air", "udid": "CCC-333", "state": "Shutdown", "isAvailable": True},
+            ],
+            "com.apple.CoreSimulator.SimRuntime.tvOS-18-0": [
+                {"name": "Apple TV", "udid": "DDD-444", "state": "Shutdown", "isAvailable": True},
+            ],
+        }
+    }
+
+    SAMPLE_RUNTIMES = {
+        "runtimes": [
+            {"name": "iOS 17.5", "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-17-5", "isAvailable": True},
+            {"name": "iOS 18.2", "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-18-2", "isAvailable": True},
+            {"name": "tvOS 18.0", "identifier": "com.apple.CoreSimulator.SimRuntime.tvOS-18-0", "isAvailable": True},
+        ]
+    }
+
+    def _make_mgr(self):
+        mgr = SimManager(SimConfig(command_backoff_base=0.01))
+        return mgr
+
+    def test_find_existing_device_preferred(self):
+        mgr = self._make_mgr()
+        with patch.object(mgr, "list_devices", return_value=self.SAMPLE_DEVICES):
+            udid = mgr.find_existing_device()
+            # Should find iPhone 16 (first in preferred list)
+            self.assertEqual(udid, "BBB-222")
+
+    def test_find_existing_device_skips_booted(self):
+        devices = {
+            "devices": {
+                "com.apple.CoreSimulator.SimRuntime.iOS-18-2": [
+                    {"name": "iPhone 16", "udid": "BBB-222", "state": "Booted", "isAvailable": True},
+                    {"name": "iPhone 15 Pro", "udid": "EEE-555", "state": "Shutdown", "isAvailable": True},
+                ],
+            }
+        }
+        mgr = self._make_mgr()
+        with patch.object(mgr, "list_devices", return_value=devices):
+            udid = mgr.find_existing_device()
+            # Should skip booted iPhone 16 and find iPhone 15 Pro
+            self.assertEqual(udid, "EEE-555")
+
+    def test_find_existing_device_runtime_filter(self):
+        mgr = self._make_mgr()
+        with patch.object(mgr, "list_devices", return_value=self.SAMPLE_DEVICES):
+            udid = mgr.find_existing_device(runtime_prefix="tvOS")
+            # No iPhones in tvOS runtime
+            self.assertIsNone(udid)
+
+    def test_find_runtime_preferred(self):
+        mgr = self._make_mgr()
+        with patch.object(mgr, "list_runtimes", return_value=self.SAMPLE_RUNTIMES):
+            runtime = mgr.find_runtime("iOS-18")
+            self.assertIn("iOS-18", runtime)
+
+    def test_find_runtime_fallback(self):
+        mgr = self._make_mgr()
+        runtimes = {"runtimes": [
+            {"name": "iOS 16.0", "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-16-0", "isAvailable": True},
+        ]}
+        with patch.object(mgr, "list_runtimes", return_value=runtimes):
+            # None of the preferred runtimes match, should fallback
+            runtime = mgr.find_runtime()
+            self.assertIn("iOS-16-0", runtime)
+
+    def test_find_runtime_no_available(self):
+        mgr = self._make_mgr()
+        with patch.object(mgr, "list_runtimes", return_value={"runtimes": []}):
+            with self.assertRaises(SimulatorNotFound):
+                mgr.find_runtime()
+
+
+class TestBootSequence(unittest.TestCase):
+    """Test boot and readiness polling."""
+
+    def test_boot_already_booted(self):
+        mgr = SimManager(SimConfig(command_backoff_base=0.01))
+        with patch.object(mgr, "get_device_state", return_value=DeviceState.BOOTED):
+            with patch.object(mgr, "_run_simctl") as mock_simctl:
+                mgr.boot("fake-udid")
+                # Should not call simctl boot
+                mock_simctl.assert_not_called()
+
+    def test_boot_handles_already_booting(self):
+        mgr = SimManager(SimConfig(command_backoff_base=0.01))
+        with patch.object(mgr, "get_device_state", return_value=DeviceState.SHUTDOWN):
+            with patch.object(mgr, "_run_simctl") as mock_simctl:
+                mock_simctl.side_effect = SimctlCommandError(
+                    ["boot"], 1, "Unable to boot device in current state: Booted"
+                )
+                # Should not raise — "already booted" is fine
+                mgr.boot("fake-udid")
+
+    def test_wait_until_booted_success(self):
+        mgr = SimManager(SimConfig(boot_poll_interval=0.01, boot_timeout=1))
+        call_count = [0]
+        def mock_state(udid):
+            call_count[0] += 1
+            if call_count[0] >= 3:
+                return DeviceState.BOOTED
+            return DeviceState.SHUTDOWN
+        with patch.object(mgr, "get_device_state", side_effect=mock_state):
+            mgr.wait_until_booted("fake-udid")
+
+    def test_wait_until_booted_timeout(self):
+        mgr = SimManager(SimConfig(boot_poll_interval=0.01, boot_timeout=0.05))
+        with patch.object(mgr, "get_device_state", return_value=DeviceState.SHUTDOWN):
+            with self.assertRaises(SimulatorBootTimeout):
+                mgr.wait_until_booted("fake-udid")
+
+    def test_wait_until_responsive_success(self):
+        mgr = SimManager(SimConfig(readiness_poll_interval=0.01, readiness_timeout=1))
+        with patch.object(mgr, "_run_simctl") as mock_simctl:
+            mock_simctl.return_value = MagicMock(returncode=0)
+            mgr.wait_until_responsive("fake-udid")
+
+    def test_wait_until_responsive_timeout(self):
+        mgr = SimManager(SimConfig(readiness_poll_interval=0.01, readiness_timeout=0.05))
+        with patch.object(mgr, "_run_simctl") as mock_simctl:
+            mock_simctl.side_effect = SimctlCommandError(["spawn"], 1, "not ready")
+            with self.assertRaises(SimulatorReadinessTimeout):
+                mgr.wait_until_responsive("fake-udid")
+
+
+class TestCleanup(unittest.TestCase):
+    """Test cleanup never raises."""
+
+    def test_cleanup_swallows_errors(self):
+        mgr = SimManager(SimConfig(command_backoff_base=0.01))
+        with patch.object(mgr, "shutdown", side_effect=SimError("shutdown failed")):
+            with patch.object(mgr, "delete", side_effect=SimError("delete failed")):
+                # Should not raise
+                mgr.cleanup("fake-udid")
+
+
+class TestCreateSimulator(unittest.TestCase):
+    """Test simulator creation."""
+
+    def test_create_returns_udid(self):
+        mgr = SimManager(SimConfig(command_backoff_base=0.01))
+        with patch.object(mgr, "find_runtime", return_value="com.apple.CoreSimulator.SimRuntime.iOS-18-2"):
+            with patch.object(mgr, "find_device_type", return_value="com.apple.CoreSimulator.SimDeviceType.iPhone-16"):
+                with patch.object(mgr, "_run_simctl") as mock_simctl:
+                    mock_simctl.return_value = MagicMock(stdout="AAAA-BBBB-CCCC\n")
+                    udid = mgr.create_simulator()
+                    self.assertEqual(udid, "AAAA-BBBB-CCCC")
+                    # Verify create was called with correct args
+                    call_args = mock_simctl.call_args[0][0]
+                    self.assertEqual(call_args[0], "create")
+
+
+class TestDiagnostics(unittest.TestCase):
+    """Test diagnostics collection."""
+
+    def test_collect_diagnostics_creates_dir(self):
+        mgr = SimManager(SimConfig(command_backoff_base=0.01))
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            diag_dir = os.path.join(tmpdir, "diag")
+            with patch.object(mgr, "_run_simctl") as mock_simctl:
+                mock_simctl.return_value = MagicMock(stdout='{"devices":{}}')
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(stdout="", returncode=0)
+                    files = mgr.collect_diagnostics("fake-udid", diag_dir)
+                    self.assertTrue(os.path.isdir(diag_dir))
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require real macOS + Xcode)
+# ---------------------------------------------------------------------------
+
+def _has_simctl():
+    """Check if xcrun simctl is available."""
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "runtimes", "-j"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+SKIP_INTEGRATION = not _has_simctl()
+SKIP_REASON = "xcrun simctl not available (requires macOS + Xcode)"
+
+
+@unittest.skipIf(SKIP_INTEGRATION, SKIP_REASON)
+class TestIntegrationDiscovery(unittest.TestCase):
+    """Integration: test real device/runtime discovery."""
+
+    def test_list_devices(self):
+        mgr = SimManager()
+        devices = mgr.list_devices()
+        self.assertIn("devices", devices)
+
+    def test_list_runtimes(self):
+        mgr = SimManager()
+        runtimes = mgr.list_runtimes()
+        self.assertIn("runtimes", runtimes)
+
+    def test_find_runtime(self):
+        mgr = SimManager()
+        runtime = mgr.find_runtime()
+        self.assertIn("iOS", runtime)
+
+    def test_find_existing_device(self):
+        mgr = SimManager()
+        # May or may not find one — just shouldn't crash
+        udid = mgr.find_existing_device()
+        if udid:
+            self.assertTrue(len(udid) > 0)
+
+
+@unittest.skipIf(SKIP_INTEGRATION, SKIP_REASON)
+class TestIntegrationLifecycle(unittest.TestCase):
+    """Integration: test full simulator lifecycle (create, boot, cleanup).
+
+    This test creates a real simulator and cleans it up afterward.
+    Takes ~30-60 seconds.
+    """
+
+    def test_full_lifecycle(self):
+        mgr = SimManager(SimConfig(
+            boot_timeout=120,
+            readiness_timeout=60,
+        ))
+        udid = None
+        try:
+            # Create
+            udid = mgr.create_simulator()
+            self.assertIsNotNone(udid)
+            self.assertTrue(len(udid) > 10)
+
+            # Verify state
+            state = mgr.get_device_state(udid)
+            self.assertEqual(state, DeviceState.SHUTDOWN)
+
+            # Boot
+            mgr.boot(udid)
+
+            # Wait for booted
+            mgr.wait_until_booted(udid)
+            state = mgr.get_device_state(udid)
+            self.assertEqual(state, DeviceState.BOOTED)
+
+            # Wait for responsive
+            mgr.wait_until_responsive(udid)
+
+        finally:
+            if udid:
+                mgr.cleanup(udid)
+                # Verify deleted (state should be None)
+                time.sleep(1)
+                state = mgr.get_device_state(udid)
+                self.assertIsNone(state)
+
+    def test_prepare_simulator(self):
+        """Test the high-level prepare_simulator convenience method."""
+        mgr = SimManager(SimConfig(
+            boot_timeout=120,
+            readiness_timeout=60,
+        ))
+        udid = None
+        try:
+            udid = mgr.prepare_simulator()
+            self.assertIsNotNone(udid)
+            state = mgr.get_device_state(udid)
+            self.assertEqual(state, DeviceState.BOOTED)
+        finally:
+            if udid:
+                mgr.cleanup(udid)
+
+
+# ---------------------------------------------------------------------------
+# CLI test
+# ---------------------------------------------------------------------------
+
+class TestCLI(unittest.TestCase):
+    """Test CLI argument parsing."""
+
+    def test_help_exits_cleanly(self):
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent / "sim_manager.py"), "--help"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("iOS Simulator lifecycle manager", result.stdout)
+
+    def test_create_help(self):
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent / "sim_manager.py"), "create", "--help"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/Swift.Bindings/src/Emitter/ModuleDatabaseEmitter.cs
+++ b/src/Swift.Bindings/src/Emitter/ModuleDatabaseEmitter.cs
@@ -124,6 +124,9 @@ namespace BindingsGeneration
             if ((record.Flags & TypeRecordFlags.HasMethodSelfTypeParams) != 0)
                 writer.WriteAttributeString("hasMethodSelfTypeParams", "true");
 
+            if ((record.Flags & TypeRecordFlags.NonCopyable) != 0)
+                writer.WriteAttributeString("nonCopyable", "true");
+
             if (!string.IsNullOrEmpty(record.RawValueTypeName))
                 writer.WriteAttributeString("rawValueType", record.RawValueTypeName);
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/ConstructorWrapperEmitter.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/ConstructorWrapperEmitter.cs
@@ -43,7 +43,77 @@ public static class ConstructorWrapperEmitter
         if (env.MethodDecl.IsAsync)
             return false;
 
+        // Skip non-copyable (~Copyable) struct types — defense-in-depth guard.
+        // Non-copyable types explicitly list Escapable in their conformances
+        // (normal types have both Copyable and Escapable implicitly, unlisted).
+        if (env.ParentDecl is StructDecl structDecl &&
+            structDecl.Conformances.Any(c => c.Protocol.ToString() == "Swift.Escapable"))
+            return false;
+
+        // Skip constructors with non-copyable (~Copyable) struct parameters.
+        // The @_cdecl wrapper passes frozen structs by value through the C ABI, which
+        // requires copying. Non-copyable types can't be copied, so the wrapper won't compile.
+        // C# passes frozen structs by value too, so there's no pointer fallback available.
+        if (HasNonCopyableStructParameter(env))
+            return false;
+
         return true;
+    }
+
+    /// <summary>
+    /// Checks whether any constructor parameter is a non-copyable (~Copyable) frozen struct.
+    /// Non-copyable types are detected by an explicit Swift.Escapable conformance in their
+    /// TypeDecl (normal Copyable types have both Copyable and Escapable implicitly, unlisted).
+    /// For cross-module types where the StructDecl isn't available, falls back to the
+    /// NonCopyable flag on the TypeRecord.
+    /// </summary>
+    private static bool HasNonCopyableStructParameter(MethodEnvironment env)
+    {
+        var moduleTypes = env.MethodDecl.ModuleDecl?.Types;
+
+        foreach (var arg in env.MethodDecl.CSSignature.Skip(1))
+        {
+            if (arg.SwiftTypeSpec is not NamedTypeSpec namedSpec)
+                continue;
+
+            // Try same-module StructDecl first (has full conformance info)
+            if (moduleTypes != null)
+            {
+                var paramStructDecl = FindStructDecl(moduleTypes, namedSpec.Name);
+                if (paramStructDecl != null)
+                {
+                    if (paramStructDecl.Conformances.Any(c => c.Protocol.ToString() == "Swift.Escapable"))
+                        return true;
+                    continue;
+                }
+            }
+
+            // Cross-module fallback: check TypeRecord.NonCopyable flag
+            if (env.TypeDatabase.TryGetTypeRecord(namedSpec, out var typeRecord) &&
+                typeRecord.Flags.HasFlag(TypeRecordFlags.NonCopyable))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Finds a StructDecl by module-qualified name in a type list (including nested types).
+    /// </summary>
+    private static StructDecl? FindStructDecl(IEnumerable<TypeDecl> types, string qualifiedName)
+    {
+        foreach (var type in types)
+        {
+            if (type is StructDecl sd && sd.SwiftTypeName?.ModuleQualifiedName == qualifiedName)
+                return sd;
+            if (type.Types?.Count > 0)
+            {
+                var nested = FindStructDecl(type.Types, qualifiedName);
+                if (nested != null) return nested;
+            }
+        }
+        return null;
     }
 
     /// <summary>
@@ -177,6 +247,17 @@ public static class ConstructorWrapperEmitter
         swiftWriter.WriteLines($$"""
             // Constructor @_cdecl wrapper for {{moduleQualifiedSwiftName}}.
             // Routes constructor through C calling convention to avoid CallConvSwift crash on NativeAOT.
+            """);
+
+        // Add @MainActor annotation when the parent type is @MainActor-isolated.
+        // Without this, calling a @MainActor init from a non-isolated @_cdecl function
+        // causes a Swift 6 compile error. Safe for synchronous functions (no runtime dispatch).
+        if (parentTypeDecl.IsMainActorIsolated)
+        {
+            swiftWriter.WriteLine("@MainActor");
+        }
+
+        swiftWriter.WriteLines($$"""
             @_cdecl("{{symbolName}}")
             """);
 
@@ -221,13 +302,13 @@ public static class ConstructorWrapperEmitter
         {
             // Failable struct constructor (non-throwing)
             swiftWriter.WriteLine($"let result: {moduleQualifiedSwiftName}? = {callExpr}");
-            swiftWriter.WriteLine($"resultPtr.initializeMemory(as: Optional<{moduleQualifiedSwiftName}>.self, repeating: result, count: 1)");
+            swiftWriter.WriteLine($"resultPtr.assumingMemoryBound(to: Optional<{moduleQualifiedSwiftName}>.self).initialize(to: result)");
         }
         else
         {
             // Non-failable, non-throwing struct constructor
             swiftWriter.WriteLine($"let result = {callExpr}");
-            swiftWriter.WriteLine($"resultPtr.initializeMemory(as: {moduleQualifiedSwiftName}.self, repeating: result, count: 1)");
+            swiftWriter.WriteLine($"resultPtr.assumingMemoryBound(to: {moduleQualifiedSwiftName}.self).initialize(to: result)");
         }
 
         swiftWriter.Indent--;
@@ -300,7 +381,7 @@ public static class ConstructorWrapperEmitter
                         $"{argLabel}{label}Val");
             }
 
-            // Non-frozen structs: pass as pointer, load value
+            // Non-frozen structs: C# passes SafeHandle (IntPtr), receive as pointer
             if (!MarshallingHelpers.IsTypeFrozen(typeRecord))
             {
                 var swiftType = ExistentialBypassEmitter.RenderSwiftTypeSpec(swiftTypeSpec);
@@ -309,22 +390,13 @@ public static class ConstructorWrapperEmitter
                         $"{argLabel}{label}Val");
             }
 
-            // Frozen structs with memory management: pass as pointer
-            if (MarshallingHelpers.RequiresMemoryManagement(typeRecord))
-            {
-                var swiftType = ExistentialBypassEmitter.RenderSwiftTypeSpec(swiftTypeSpec);
-                return ($"_ {label}: UnsafeRawPointer",
-                        $"let {label}Val = {label}.load(as: {swiftType}.self)",
-                        $"{argLabel}{label}Val");
-            }
-
-            // Frozen structs (blittable): pass as pointer, load value
+            // Frozen structs (including those with memory management like String):
+            // C# passes the struct value directly (Buffer or blittable struct),
+            // so @_cdecl must accept the Swift type by value — not as a pointer.
             if (MarshallingHelpers.IsTypeFrozen(typeRecord))
             {
                 var swiftType = ExistentialBypassEmitter.RenderSwiftTypeSpec(swiftTypeSpec);
-                return ($"_ {label}: UnsafeRawPointer",
-                        $"let {label}Val = {label}.load(as: {swiftType}.self)",
-                        $"{argLabel}{label}Val");
+                return ($"_ {label}: {swiftType}", null, $"{argLabel}{label}");
             }
         }
 
@@ -360,17 +432,17 @@ public static class ConstructorWrapperEmitter
     /// </summary>
     private static string GetSwiftRawValueType(string? rawValueTypeName) => rawValueTypeName switch
     {
-        "Swift.Int" => "Int",
-        "Swift.UInt" => "UInt",
-        "Swift.Int8" => "Int8",
-        "Swift.UInt8" => "UInt8",
-        "Swift.Int16" => "Int16",
-        "Swift.UInt16" => "UInt16",
-        "Swift.Int32" => "Int32",
-        "Swift.UInt32" => "UInt32",
-        "Swift.Int64" => "Int64",
-        "Swift.UInt64" => "UInt64",
-        "Swift.String" => "String",
+        "Swift.Int" or "Int" => "Int",
+        "Swift.UInt" or "UInt" => "UInt",
+        "Swift.Int8" or "Int8" => "Int8",
+        "Swift.UInt8" or "UInt8" => "UInt8",
+        "Swift.Int16" or "Int16" => "Int16",
+        "Swift.UInt16" or "UInt16" => "UInt16",
+        "Swift.Int32" or "Int32" => "Int32",
+        "Swift.UInt32" or "UInt32" => "UInt32",
+        "Swift.Int64" or "Int64" => "Int64",
+        "Swift.UInt64" or "UInt64" => "UInt64",
+        "Swift.String" or "String" => "String",
         _ => "Int" // fallback
     };
 
@@ -416,7 +488,7 @@ public static class ConstructorWrapperEmitter
             sw.WriteLines($$"""
                 do {
                     let result: {{swiftTypeName}}? = try {{callExpr}}
-                    resultPtr.initializeMemory(as: Optional<{{swiftTypeName}}>.self, repeating: result, count: 1)
+                    resultPtr.assumingMemoryBound(to: Optional<{{swiftTypeName}}>.self).initialize(to: result)
                 } catch {
                     errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()
                 }
@@ -427,7 +499,7 @@ public static class ConstructorWrapperEmitter
             sw.WriteLines($$"""
                 do {
                     let result = try {{callExpr}}
-                    resultPtr.initializeMemory(as: {{swiftTypeName}}.self, repeating: result, count: 1)
+                    resultPtr.assumingMemoryBound(to: {{swiftTypeName}}.self).initialize(to: result)
                 } catch {
                     errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()
                 }

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/ConstructorWrapperEmitter.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/ConstructorWrapperEmitter.cs
@@ -1,0 +1,437 @@
+// Copyright (c) 2026 Justin Wojciechowski.
+// Licensed under the MIT License.
+
+namespace BindingsGeneration;
+
+/// <summary>
+/// Emits per-constructor @_cdecl Swift wrappers that route constructor P/Invokes
+/// through C calling convention, eliminating CallConvSwift ABI mismatches on NativeAOT/ARM64.
+///
+/// For each constructor, generates a @_cdecl free function in the wrapper library that:
+/// - Receives C-compatible parameters (primitives pass through, structs/classes as UnsafeRawPointer)
+/// - Calls the actual Swift init
+/// - Returns the result via C ABI (class → retained pointer, struct → writes to result buffer)
+///
+/// Handles failable (init?), throwing (init() throws), and combined (init?() throws) constructors.
+/// Follows the DestroyWrapperEmitter pattern. State tracked on <see cref="ModuleEmissionContext"/>.
+/// </summary>
+public static class ConstructorWrapperEmitter
+{
+    /// <summary>
+    /// Pure query: determines whether a constructor should use a @_cdecl wrapper.
+    /// Guards: xcframework mode (wrapper lib exists), non-generic parent type,
+    /// no closure parameters (deferred to follow-up).
+    /// </summary>
+    public static bool ShouldEmitWrapper(MethodEnvironment env)
+    {
+        if (!env.MethodDecl.IsConstructor)
+            return false;
+
+        // Only in xcframework mode where the wrapper library exists
+        if (string.IsNullOrEmpty(env.TypeDatabase.AsyncLibraryName))
+            return false;
+
+        // Skip generic parent types — Swift can't express generic params in @_cdecl free functions
+        if (env.ParentDecl is TypeDecl typeDecl && typeDecl.IsGeneric)
+            return false;
+
+        // Skip constructors with closure parameters (deferred complexity)
+        if (env.MethodDecl.CSSignature.Skip(1).Any(env.ClosureHandler.IsClosure))
+            return false;
+
+        // Skip async constructors (async uses its own wrapper pattern)
+        if (env.MethodDecl.IsAsync)
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the @_cdecl symbol name for a constructor wrapper.
+    /// Pure function — no side effects, safe to call before emission.
+    /// </summary>
+    /// <param name="moduleName">The Swift module name (e.g., "Lottie").</param>
+    /// <param name="typeName">The Swift type name (e.g., "LottieAnimationView").</param>
+    /// <param name="originalMangledName">The original mangled name to hash for uniqueness.</param>
+    public static string GetConstructorSymbolName(string moduleName, string typeName, string originalMangledName)
+    {
+        var hash = EmitterUtility.DeterministicHash8(originalMangledName);
+        var safeTypeName = typeName.Replace(".", "_");
+        return $"SBW_{moduleName}_{safeTypeName}_init_{hash}";
+    }
+
+    /// <summary>
+    /// Emits a Swift @_cdecl wrapper function for a constructor.
+    /// The wrapper receives C-compatible parameters, calls the Swift init,
+    /// and returns the result via C ABI.
+    /// </summary>
+    /// <param name="swiftWriter">The Swift writer for the wrapper .swift file.</param>
+    /// <param name="env">The method environment with constructor info.</param>
+    /// <param name="ctx">The per-module emission context for dedup tracking.</param>
+    /// <param name="silgenTarget">Optional @_silgen_name symbol to call instead of direct init (for default param overloads).</param>
+    public static void EmitSwiftConstructorWrapper(
+        SwiftWriter swiftWriter,
+        MethodEnvironment env,
+        ModuleEmissionContext? ctx = null,
+        string? silgenTarget = null)
+    {
+        ctx ??= ModuleEmissionContext.Default;
+
+        var methodDecl = env.MethodDecl;
+        var parentTypeDecl = env.ParentDecl as TypeDecl;
+        if (parentTypeDecl == null) return;
+
+        var symbolName = methodDecl.MangledName; // Already set to cdecl symbol by caller
+        if (!ctx.TryAddConstructorWrapperSymbol(symbolName))
+            return; // Already emitted
+
+        var moduleName = parentTypeDecl.SwiftTypeName.Module;
+        var moduleQualifiedSwiftName = parentTypeDecl.SwiftTypeName.ModuleQualifiedName;
+
+        bool isClass = env.ParentDecl is ClassDecl;
+        bool isFailable = methodDecl.IsFailable;
+        bool throws = methodDecl.Throws;
+        bool requiresIndirectResult = !isClass || isFailable; // Structs always, failable always
+
+        // For classes: non-failable returns pointer, failable still uses indirect for Optional<Self>
+        // Actually: failable class returns UnsafeMutableRawPointer? (nullable pointer)
+        // Failable struct writes Optional<Self> to result buffer
+        bool isFailableClass = isFailable && isClass;
+        bool isFailableStruct = isFailable && !isClass;
+        bool needsResultBuffer = !isClass || isFailableStruct;
+        // Non-failable class: returns pointer directly (no result buffer)
+        // Failable class: returns nullable pointer (no result buffer)
+        // Non-failable struct: writes to result buffer
+        // Failable struct: writes Optional<Self> to result buffer
+        needsResultBuffer = !isClass;
+
+        // Build Swift parameter list for the @_cdecl wrapper
+        var swiftParams = new List<string>();
+
+        // Result buffer parameter (first, for struct constructors)
+        if (needsResultBuffer)
+        {
+            swiftParams.Add("_ resultPtr: UnsafeMutableRawPointer");
+        }
+
+        // Error out-pointer parameter (for throwing constructors)
+        if (throws)
+        {
+            swiftParams.Add("_ errorOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>");
+        }
+
+        // Build parameter reconstruction lines and @_cdecl params
+        var reconstructionLines = new List<string>();
+        var callArgs = new List<string>();
+        var keptArgs = methodDecl.CSSignature.Skip(1).ToList();
+
+        for (int i = 0; i < keptArgs.Count; i++)
+        {
+            var arg = keptArgs[i];
+            // Skip debug params and empty tuples (already stripped by this point)
+            if (DefaultParameterOverloadEmitter.IsDebugParameter(arg))
+                continue;
+            if (arg.SwiftTypeSpec.IsEmptyTuple)
+                continue;
+
+            var label = !string.IsNullOrEmpty(arg.PrivateName) ? arg.PrivateName : arg.Name;
+            var (cdeclParam, reconstruction, callArg) = GetCdeclParamMapping(arg, label, env);
+            swiftParams.Add(cdeclParam);
+            if (reconstruction != null)
+                reconstructionLines.Add(reconstruction);
+            callArgs.Add(callArg);
+        }
+
+        var swiftParamString = string.Join(", ", swiftParams);
+
+        // Build return type
+        string returnClause;
+        if (isClass && !isFailable)
+            returnClause = " -> UnsafeMutableRawPointer";
+        else if (isFailableClass)
+            returnClause = " -> UnsafeMutableRawPointer?";
+        else
+            returnClause = ""; // void (writes to resultPtr)
+
+        // Build the Swift function name (internal, doesn't need to be pretty)
+        var swiftFuncName = $"_sbw_init_{EmitterUtility.DeterministicHash8(symbolName)}";
+
+        // Build call arguments string
+        var callArgString = string.Join(", ", callArgs);
+
+        // Build the call expression
+        string callExpr;
+        if (silgenTarget != null)
+        {
+            // Default param overload: call the @_silgen_name wrapper via its extension method
+            // The @_silgen_name wrapper is a static factory on the type
+            callExpr = $"{moduleQualifiedSwiftName}.{silgenTarget}({callArgString})";
+        }
+        else
+        {
+            callExpr = $"{moduleQualifiedSwiftName}({callArgString})";
+        }
+
+        // Emit the @_cdecl function
+        swiftWriter.WriteLine();
+        swiftWriter.WriteLines($$"""
+            // Constructor @_cdecl wrapper for {{moduleQualifiedSwiftName}}.
+            // Routes constructor through C calling convention to avoid CallConvSwift crash on NativeAOT.
+            @_cdecl("{{symbolName}}")
+            """);
+
+        swiftWriter.WriteLine($"public func {swiftFuncName}({swiftParamString}){returnClause} {{");
+        swiftWriter.Indent++;
+
+        // Emit parameter reconstruction lines
+        foreach (var line in reconstructionLines)
+        {
+            swiftWriter.WriteLine(line);
+        }
+
+        // Emit the body based on constructor type
+        if (throws && isClass && !isFailable)
+        {
+            // Throwing class constructor
+            EmitThrowingClassBody(swiftWriter, callExpr);
+        }
+        else if (throws && isFailableClass)
+        {
+            // Failable + throwing class constructor
+            EmitFailableThrowingClassBody(swiftWriter, callExpr);
+        }
+        else if (throws && !isClass)
+        {
+            // Throwing struct constructor
+            EmitThrowingStructBody(swiftWriter, callExpr, moduleQualifiedSwiftName, isFailable);
+        }
+        else if (isFailableClass)
+        {
+            // Failable class constructor (non-throwing)
+            swiftWriter.WriteLine($"guard let result = {callExpr} else {{ return nil }}");
+            swiftWriter.WriteLine("return Unmanaged.passRetained(result).toOpaque()");
+        }
+        else if (isClass)
+        {
+            // Non-failable, non-throwing class constructor
+            swiftWriter.WriteLine($"let result = {callExpr}");
+            swiftWriter.WriteLine("return Unmanaged.passRetained(result).toOpaque()");
+        }
+        else if (isFailableStruct)
+        {
+            // Failable struct constructor (non-throwing)
+            swiftWriter.WriteLine($"let result: {moduleQualifiedSwiftName}? = {callExpr}");
+            swiftWriter.WriteLine($"resultPtr.initializeMemory(as: Optional<{moduleQualifiedSwiftName}>.self, repeating: result, count: 1)");
+        }
+        else
+        {
+            // Non-failable, non-throwing struct constructor
+            swiftWriter.WriteLine($"let result = {callExpr}");
+            swiftWriter.WriteLine($"resultPtr.initializeMemory(as: {moduleQualifiedSwiftName}.self, repeating: result, count: 1)");
+        }
+
+        swiftWriter.Indent--;
+        swiftWriter.WriteLine("}");
+    }
+
+    /// <summary>
+    /// Maps a constructor parameter to its @_cdecl-compatible Swift type, reconstruction code,
+    /// and call argument expression.
+    /// </summary>
+    private static (string cdeclParam, string? reconstruction, string callArg) GetCdeclParamMapping(
+        ArgumentDecl arg, string label, MethodEnvironment env)
+    {
+        var swiftTypeSpec = arg.SwiftTypeSpec;
+
+        // Determine the Swift argument label for the init call
+        var argLabel = arg.Name switch
+        {
+            var n when n.StartsWith("arg") => "",
+            var n when n.StartsWith("_") => $"{n.Substring(1)}: ",
+            var n when string.IsNullOrEmpty(n) => "",
+            var n => $"{n}: "
+        };
+
+        // Primitives pass through directly
+        if (IsCdeclPrimitive(swiftTypeSpec))
+        {
+            var swiftType = ExistentialBypassEmitter.RenderSwiftTypeSpec(swiftTypeSpec);
+
+            // Bool: Swift @_cdecl receives Int8, needs != 0 conversion
+            if (MarshallingHelpers.IsBoolType(swiftType) || swiftType == "Bool")
+            {
+                return ($"_ {label}: Int8",
+                        $"let {label}Val = {label} != 0",
+                        $"{argLabel}{label}Val");
+            }
+
+            return ($"_ {label}: {swiftType}", null, $"{argLabel}{label}");
+        }
+
+        // Classes: receive as UnsafeMutableRawPointer, reconstruct via Unmanaged
+        if (env.TypeDatabase.TryGetTypeRecord(swiftTypeSpec, out var typeRecord))
+        {
+            if (typeRecord.Kind == TypeRecordKind.Class ||
+                MarshallingHelpers.IsObjCBridged(typeRecord) ||
+                MarshallingHelpers.IsObjCRooted(typeRecord))
+            {
+                var swiftType = ExistentialBypassEmitter.RenderSwiftTypeSpec(swiftTypeSpec);
+                return ($"_ {label}: UnsafeMutableRawPointer",
+                        $"let {label}Val = Unmanaged<{swiftType}>.fromOpaque({label}).takeUnretainedValue()",
+                        $"{argLabel}{label}Val");
+            }
+
+            // Simple enums: pass raw value directly
+            if (typeRecord.Kind == TypeRecordKind.Enum && typeRecord.Flags.HasFlag(TypeRecordFlags.SimpleEnum))
+            {
+                var swiftType = ExistentialBypassEmitter.RenderSwiftTypeSpec(swiftTypeSpec);
+                var rawType = GetSwiftRawValueType(typeRecord.RawValueTypeName);
+                return ($"_ {label}: {rawType}",
+                        $"let {label}Val = {swiftType}(rawValue: {label})!",
+                        $"{argLabel}{label}Val");
+            }
+
+            // Complex enums: pass as pointer
+            if (typeRecord.Kind == TypeRecordKind.Enum)
+            {
+                var swiftType = ExistentialBypassEmitter.RenderSwiftTypeSpec(swiftTypeSpec);
+                return ($"_ {label}: UnsafeRawPointer",
+                        $"let {label}Val = {label}.load(as: {swiftType}.self)",
+                        $"{argLabel}{label}Val");
+            }
+
+            // Non-frozen structs: pass as pointer, load value
+            if (!MarshallingHelpers.IsTypeFrozen(typeRecord))
+            {
+                var swiftType = ExistentialBypassEmitter.RenderSwiftTypeSpec(swiftTypeSpec);
+                return ($"_ {label}: UnsafeRawPointer",
+                        $"let {label}Val = {label}.load(as: {swiftType}.self)",
+                        $"{argLabel}{label}Val");
+            }
+
+            // Frozen structs with memory management: pass as pointer
+            if (MarshallingHelpers.RequiresMemoryManagement(typeRecord))
+            {
+                var swiftType = ExistentialBypassEmitter.RenderSwiftTypeSpec(swiftTypeSpec);
+                return ($"_ {label}: UnsafeRawPointer",
+                        $"let {label}Val = {label}.load(as: {swiftType}.self)",
+                        $"{argLabel}{label}Val");
+            }
+
+            // Frozen structs (blittable): pass as pointer, load value
+            if (MarshallingHelpers.IsTypeFrozen(typeRecord))
+            {
+                var swiftType = ExistentialBypassEmitter.RenderSwiftTypeSpec(swiftTypeSpec);
+                return ($"_ {label}: UnsafeRawPointer",
+                        $"let {label}Val = {label}.load(as: {swiftType}.self)",
+                        $"{argLabel}{label}Val");
+            }
+        }
+
+        // Fallback: pass as UnsafeRawPointer
+        var fallbackSwiftType = ExistentialBypassEmitter.RenderSwiftTypeSpec(swiftTypeSpec);
+        return ($"_ {label}: UnsafeRawPointer",
+                $"let {label}Val = {label}.load(as: {fallbackSwiftType}.self)",
+                $"{argLabel}{label}Val");
+    }
+
+    /// <summary>
+    /// Returns true for types that can be passed directly through the C ABI
+    /// without pointer wrapping (integers, floats, etc.).
+    /// </summary>
+    private static bool IsCdeclPrimitive(TypeSpec typeSpec)
+    {
+        if (typeSpec is not NamedTypeSpec named)
+            return false;
+
+        return named.Name switch
+        {
+            "Swift.Int" or "Swift.UInt" or "Swift.Int8" or "Swift.UInt8" or
+            "Swift.Int16" or "Swift.UInt16" or "Swift.Int32" or "Swift.UInt32" or
+            "Swift.Int64" or "Swift.UInt64" or
+            "Swift.Float" or "Swift.Double" or "Swift.Bool" or
+            "CoreFoundation.CGFloat" => true,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Maps C# enum underlying type names to Swift raw value type names.
+    /// </summary>
+    private static string GetSwiftRawValueType(string? rawValueTypeName) => rawValueTypeName switch
+    {
+        "Swift.Int" => "Int",
+        "Swift.UInt" => "UInt",
+        "Swift.Int8" => "Int8",
+        "Swift.UInt8" => "UInt8",
+        "Swift.Int16" => "Int16",
+        "Swift.UInt16" => "UInt16",
+        "Swift.Int32" => "Int32",
+        "Swift.UInt32" => "UInt32",
+        "Swift.Int64" => "Int64",
+        "Swift.UInt64" => "UInt64",
+        "Swift.String" => "String",
+        _ => "Int" // fallback
+    };
+
+    /// <summary>
+    /// Emits the body of a throwing class constructor wrapper.
+    /// </summary>
+    private static void EmitThrowingClassBody(SwiftWriter sw, string callExpr)
+    {
+        sw.WriteLines($$"""
+            do {
+                let result = try {{callExpr}}
+                return Unmanaged.passRetained(result).toOpaque()
+            } catch {
+                errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()
+                return UnsafeMutableRawPointer(bitPattern: 1)!
+            }
+            """);
+    }
+
+    /// <summary>
+    /// Emits the body of a failable+throwing class constructor wrapper.
+    /// </summary>
+    private static void EmitFailableThrowingClassBody(SwiftWriter sw, string callExpr)
+    {
+        sw.WriteLines($$"""
+            do {
+                guard let result = try {{callExpr}} else { return nil }
+                return Unmanaged.passRetained(result).toOpaque()
+            } catch {
+                errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()
+                return nil
+            }
+            """);
+    }
+
+    /// <summary>
+    /// Emits the body of a throwing struct constructor wrapper.
+    /// </summary>
+    private static void EmitThrowingStructBody(SwiftWriter sw, string callExpr, string swiftTypeName, bool isFailable)
+    {
+        if (isFailable)
+        {
+            sw.WriteLines($$"""
+                do {
+                    let result: {{swiftTypeName}}? = try {{callExpr}}
+                    resultPtr.initializeMemory(as: Optional<{{swiftTypeName}}>.self, repeating: result, count: 1)
+                } catch {
+                    errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()
+                }
+                """);
+        }
+        else
+        {
+            sw.WriteLines($$"""
+                do {
+                    let result = try {{callExpr}}
+                    resultPtr.initializeMemory(as: {{swiftTypeName}}.self, repeating: result, count: 1)
+                } catch {
+                    errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()
+                }
+                """);
+        }
+    }
+}

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/DefaultParameterOverloadEmitter.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/DefaultParameterOverloadEmitter.cs
@@ -84,6 +84,25 @@ public static class DefaultParameterOverloadEmitter
                 env.PInvokeHelperContext,
                 env.CompositionCollector);
 
+            // Set @_cdecl constructor wrapper flags BEFORE SignatureHandler construction.
+            // Compute the @_cdecl symbol from the original MangledName (before EmitSwiftWrapper changes it).
+            string? silgenSymbolForCdecl = null;
+            string? cdeclSymbolForRestore = null;
+            if (overloadDecl.IsConstructor && ConstructorWrapperEmitter.ShouldEmitWrapper(overloadEnv))
+            {
+                var parentType_ = overloadDecl.ParentDecl as TypeDecl;
+                // Save the @_silgen_name symbol (current MangledName = DBW_...) — the @_cdecl wrapper calls it
+                silgenSymbolForCdecl = overloadDecl.MangledName;
+                var cdeclSymbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+                    parentType_!.SwiftTypeName.Module,
+                    parentType_.Name,
+                    overloadDecl.MangledName);
+                cdeclSymbolForRestore = cdeclSymbol;
+                overloadDecl.UsesCdeclConstructorWrapper = true;
+                // UsesWrapperLibrary already set by BuildOverloadDecl
+                overloadDecl.MangledName = cdeclSymbol;
+            }
+
             // Check if the overload signature is fully marshallable
             var signatureHandler = new SignatureHandler(overloadEnv);
             if (signatureHandler.GetWrapperSignature().ContainsPlaceholder)
@@ -111,8 +130,29 @@ public static class DefaultParameterOverloadEmitter
                 }
             }
 
-            // Emit Swift wrapper
+            // EmitSwiftWrapper reads overloadDecl.MangledName as the @_silgen_name symbol.
+            // If using cdecl, temporarily restore the DBW_... symbol for the Swift wrapper emission.
+            if (cdeclSymbolForRestore != null)
+                overloadDecl.MangledName = silgenSymbolForCdecl!;
+
+            // Emit Swift @_silgen_name wrapper
             EmitSwiftWrapper(swiftWriter, methodDecl, overloadDecl, env);
+
+            // Restore the cdecl symbol as the final MangledName for P/Invoke routing.
+            // EmitSwiftWrapper sets MangledName = wrapperSymbol (the DBW_... name) — overwrite with cdecl.
+            if (cdeclSymbolForRestore != null)
+                overloadDecl.MangledName = cdeclSymbolForRestore;
+
+            // Emit @_cdecl constructor wrapper that calls the @_silgen_name function
+            if (silgenSymbolForCdecl != null && overloadDecl.UsesCdeclConstructorWrapper)
+            {
+                // The @_silgen_name function is a static factory — compute its Swift name
+                var trimCount = methodDecl.CSSignature.Count - overloadDecl.CSSignature.Count;
+                var rawMethodName = methodDecl.GetSwiftName();
+                var silgenFuncName = $"_dbw_{rawMethodName}_{DeterministicHash8(methodDecl.MangledName)}_{trimCount}";
+                ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(
+                    swiftWriter, overloadEnv, emissionContext, silgenTarget: silgenFuncName);
+            }
 
             // Delegate C# emission to normal pipeline
             TypeDatabaseExtensions.AnyTypeFallbackInfo? fallbackInfo = null;

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -702,6 +702,23 @@ namespace BindingsGeneration
                 DefaultParameterOverloadEmitter.EmitDebugParamWrapper(swiftWriter, methodEnv);
             }
 
+            // Set @_cdecl constructor wrapper flags BEFORE SignatureHandler creation.
+            // SignatureHandler reads UsesCdeclConstructorWrapper to decide SwiftIndirectResult vs IntPtr
+            // and MangledName to compute the P/Invoke method name via GetPInvokeName().
+            string? originalMangledNameForCtor = null;
+            if (ConstructorWrapperEmitter.ShouldEmitWrapper(methodEnv))
+            {
+                var parentType_ = methodEnv.ParentDecl as TypeDecl;
+                var cdeclSymbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+                    parentType_!.SwiftTypeName.Module,
+                    parentType_.Name,
+                    methodEnv.MethodDecl.MangledName);
+                originalMangledNameForCtor = methodEnv.MethodDecl.MangledName;
+                methodEnv.MethodDecl.UsesCdeclConstructorWrapper = true;
+                methodEnv.MethodDecl.UsesWrapperLibrary = true;
+                methodEnv.MethodDecl.MangledName = cdeclSymbol;
+            }
+
             var signatureHandler = new SignatureHandler(methodEnv);
 
             if (signatureHandler.GetWrapperSignature().ContainsPlaceholder)
@@ -774,6 +791,13 @@ namespace BindingsGeneration
             if (!isAccessor && ThrowingClosureSimplificationEmitter.ShouldSimplify(methodEnv))
             {
                 methodEnv.MethodDecl.HasThrowingClosureSimplification = true;
+            }
+
+            // Emit Swift @_cdecl constructor wrapper AFTER signature validation, BEFORE WrapperEmitter.
+            if (methodEnv.MethodDecl.UsesCdeclConstructorWrapper)
+            {
+                ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(
+                    swiftWriter, methodEnv, context.GetEmissionContext());
             }
 
             var wrapperEmitter = new WrapperEmitter(methodEnv, signatureHandler, fallbackInfo, context.GetEmissionContext());

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -316,6 +316,21 @@ namespace BindingsGeneration
                 DefaultParameterOverloadEmitter.EmitDebugParamWrapper(swiftWriter, methodEnv);
             }
 
+            // Set @_cdecl constructor wrapper flags BEFORE SignatureHandler creation.
+            // SignatureHandler reads UsesCdeclConstructorWrapper to decide SwiftIndirectResult vs IntPtr
+            // and MangledName to compute the P/Invoke method name via GetPInvokeName().
+            if (ConstructorWrapperEmitter.ShouldEmitWrapper(methodEnv))
+            {
+                var parentType_ = methodEnv.ParentDecl as TypeDecl;
+                var cdeclSymbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+                    parentType_!.SwiftTypeName.Module,
+                    parentType_.Name,
+                    methodEnv.MethodDecl.MangledName);
+                methodEnv.MethodDecl.UsesCdeclConstructorWrapper = true;
+                methodEnv.MethodDecl.UsesWrapperLibrary = true;
+                methodEnv.MethodDecl.MangledName = cdeclSymbol;
+            }
+
             var signatureHandler = new SignatureHandler(methodEnv);
 
             if (signatureHandler.GetWrapperSignature().ContainsPlaceholder)
@@ -356,6 +371,13 @@ namespace BindingsGeneration
             }
 
             MethodHandler.CheckExportedSymbol(methodEnv);
+
+            // Emit Swift @_cdecl constructor wrapper AFTER signature validation, BEFORE WrapperEmitter.
+            if (methodEnv.MethodDecl.UsesCdeclConstructorWrapper)
+            {
+                ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(
+                    swiftWriter, methodEnv, context.GetEmissionContext());
+            }
 
             var wrapperEmitter = new WrapperEmitter(methodEnv, signatureHandler, emissionContext: context.GetEmissionContext());
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PInvokeEmitter.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PInvokeEmitter.cs
@@ -128,7 +128,15 @@ namespace BindingsGeneration
 
             if (MarshallingHelpers.MethodRequiresIndirectResult(_env))
             {
-                AddParameter("SwiftIndirectResult", "swiftIndirectResult");
+                if (_env.MethodDecl.UsesCdeclConstructorWrapper)
+                {
+                    // @_cdecl wrapper: plain IntPtr result buffer, not SwiftIndirectResult register
+                    AddParameter("IntPtr", "resultPtr");
+                }
+                else
+                {
+                    AddParameter("SwiftIndirectResult", "swiftIndirectResult");
+                }
                 SetReturnType("void");
                 return;
             }
@@ -572,7 +580,16 @@ namespace BindingsGeneration
 
             if (_env.MethodDecl.Throws)
             {
-                AddParameter("SwiftError", "swiftError", "out");
+                if (_env.MethodDecl.UsesCdeclConstructorWrapper)
+                {
+                    // @_cdecl wrapper: error reported via out-pointer, not SwiftError register.
+                    // 'out IntPtr' marshals as a pointer parameter — callee writes through it.
+                    AddParameter("IntPtr", "errorPtr", "out");
+                }
+                else
+                {
+                    AddParameter("SwiftError", "swiftError", "out");
+                }
             }
         }
 
@@ -708,7 +725,10 @@ namespace BindingsGeneration
                     ReturnType = pInvokeSignature.ReturnType,
                     ParametersString = pInvokeParams,
                     IsAsync = methodDecl.IsAsync,
-                    IsUnsafe = pInvokeParams.Contains("void*") || pInvokeParams.Contains("delegate*")
+                    IsUnsafe = pInvokeParams.Contains("void*") || pInvokeParams.Contains("delegate*") || pInvokeParams.Contains("IntPtr*"),
+                    CallingConvention = methodDecl.UsesCdeclConstructorWrapper
+                        ? PInvokeCallingConvention.Cdecl
+                        : PInvokeCallingConvention.Swift
                 });
             }
         }

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/WrapperEmitter.FailableFactory.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/WrapperEmitter.FailableFactory.cs
@@ -75,8 +75,11 @@ namespace BindingsGeneration
             csWriter.WriteLine("{");
             csWriter.Indent++;
 
-            // Create SwiftIndirectResult pointing to the optional buffer
-            csWriter.WriteLine("var swiftIndirectResult = new SwiftIndirectResult(resultBuffer);");
+            // Create result buffer variable — either SwiftIndirectResult (Swift ABI) or plain IntPtr (cdecl)
+            if (_env.MethodDecl.UsesCdeclConstructorWrapper)
+                csWriter.WriteLine("var resultPtr = (IntPtr)resultBuffer;");
+            else
+                csWriter.WriteLine("var swiftIndirectResult = new SwiftIndirectResult(resultBuffer);");
             csWriter.WriteLine();
 
             // Marshal arguments using existing helpers

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/WrapperEmitter.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/WrapperEmitter.cs
@@ -232,9 +232,12 @@ namespace BindingsGeneration
 
             if (_requiresIndirectResult)
             {
-                // Non-frozen struct constructors: result goes into buf via SwiftIndirectResult
+                // Non-frozen struct constructors: result goes into buf via SwiftIndirectResult or IntPtr
                 csWriter.WriteLine("IntPtr* buf = stackalloc IntPtr[1];");
-                csWriter.WriteLine("var swiftIndirectResult = new SwiftIndirectResult(buf);");
+                if (_env.MethodDecl.UsesCdeclConstructorWrapper)
+                    csWriter.WriteLine("var resultPtr = (IntPtr)buf;");
+                else
+                    csWriter.WriteLine("var swiftIndirectResult = new SwiftIndirectResult(buf);");
                 EmitPInvokeCall(csWriter);
                 EmitSwiftError(csWriter);
                 csWriter.WriteLine("if (*buf == IntPtr.Zero)");

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/ModuleEmissionContext.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/ModuleEmissionContext.cs
@@ -225,6 +225,16 @@ public sealed class ModuleEmissionContext
     /// <summary>Adds a destroy wrapper symbol. Returns true if newly added.</summary>
     public bool TryAddDestroyWrapperSymbol(string symbol) => _destroyWrapperSymbols.Add(symbol);
 
+    // ==================== Constructor Wrapper ====================
+
+    private readonly HashSet<string> _constructorWrapperSymbols = new();
+
+    /// <summary>Checks if a constructor @_cdecl wrapper symbol was already emitted for this type.</summary>
+    public bool HasConstructorWrapperSymbol(string symbol) => _constructorWrapperSymbols.Contains(symbol);
+
+    /// <summary>Adds a constructor wrapper symbol. Returns true if newly added.</summary>
+    public bool TryAddConstructorWrapperSymbol(string symbol) => _constructorWrapperSymbols.Add(symbol);
+
     // ==================== Enum Handler RawRepresentable ====================
 
     private readonly HashSet<string> _enumRawRepSymbols = new();

--- a/src/Swift.Bindings/src/Marshaler/Projection/MethodMarshalPlanBuilder.cs
+++ b/src/Swift.Bindings/src/Marshaler/Projection/MethodMarshalPlanBuilder.cs
@@ -311,6 +311,19 @@ internal class MethodMarshalPlanBuilder
                 safeHandleTypeName = GenericTypeEmitter.GetTypeNameWithGenerics(root);
             }
 
+            if (_env.MethodDecl.UsesCdeclConstructorWrapper)
+            {
+                return new IndirectResultSetup
+                {
+                    IsConstructor = true,
+                    ReturnTypeName = typeName,
+                    AllocationCode = $$"""
+                        _payload = new SwiftSafeHandle<{{safeHandleTypeName}}>((IntPtr)NativeMemory.Alloc(_payloadSize));
+                        var resultPtr = _payload.DangerousGetHandle();
+                        """
+                };
+            }
+
             return new IndirectResultSetup
             {
                 IsConstructor = true,
@@ -365,18 +378,134 @@ internal class MethodMarshalPlanBuilder
         // Prefix all calls with the helper class name.
         var hp = _env.PInvokeHelperContext != null ? $"{_env.PInvokeHelperContext.HelperClassName}." : "";
 
+        // @_cdecl constructor wrappers use out IntPtr errorPtr instead of SwiftError swiftError.
+        // The error pointer is the same retained AnyObject as SwiftError.Value — all downstream
+        // error infrastructure (SBW_GetErrorDescription, SBW_ReleaseError) works identically.
+        bool isCdeclConstructor = _env.MethodDecl.UsesCdeclConstructorWrapper;
+
         string errorCheckCode;
         if (syncTypedErrorType != null)
         {
-            // C2: Typed throws — extract error value with nil-check fallback.
-            // SBW_ReleaseError is in the outermost finally, guaranteeing exactly-once release.
-            errorCheckCode = $$"""
-                if (swiftError.Value != null)
-                {
-                    string _errorMessage;
-                    var _errorPtr = (IntPtr)swiftError.Value;
-                    try
+            if (isCdeclConstructor)
+            {
+                // C2: Typed throws via @_cdecl out-pointer
+                errorCheckCode = $$"""
+                    if (errorPtr != IntPtr.Zero)
                     {
+                        string _errorMessage;
+                        try
+                        {
+                            var _descPtr = {{hp}}SBW_GetErrorDescription(errorPtr);
+                            try
+                            {
+                                _errorMessage = _descPtr != IntPtr.Zero
+                                    ? System.Runtime.InteropServices.Marshal.PtrToStringUTF8(_descPtr) ?? "Unknown Swift error"
+                                    : "Unknown Swift error";
+                            }
+                            finally
+                            {
+                                if (_descPtr != IntPtr.Zero) {{hp}}SBW_Free(_descPtr);
+                            }
+                            var _typedErrorPtr = {{hp}}SBW_ExtractTypedError_{{typedErrorSafeSuffix}}(errorPtr);
+                            if (_typedErrorPtr != IntPtr.Zero)
+                            {
+                                try
+                                {
+                                    var _typedError = ({{syncTypedErrorType}})SwiftMarshal.MarshalFromSwift<{{syncTypedErrorType}}>(_typedErrorPtr);
+                                    throw new SwiftException<{{syncTypedErrorType}}>(_typedError, _errorMessage);
+                                }
+                                finally
+                                {
+                                    {{hp}}SBW_Free(_typedErrorPtr);
+                                }
+                            }
+                            throw new SwiftException<{{syncTypedErrorType}}>(_errorMessage);
+                        }
+                        finally
+                        {
+                            {{hp}}SBW_ReleaseError(errorPtr);
+                        }
+                    }
+                    """;
+            }
+            else
+            {
+                // C2: Typed throws — extract error value with nil-check fallback.
+                // SBW_ReleaseError is in the outermost finally, guaranteeing exactly-once release.
+                errorCheckCode = $$"""
+                    if (swiftError.Value != null)
+                    {
+                        string _errorMessage;
+                        var _errorPtr = (IntPtr)swiftError.Value;
+                        try
+                        {
+                            var _descPtr = {{hp}}SBW_GetErrorDescription(_errorPtr);
+                            try
+                            {
+                                _errorMessage = _descPtr != IntPtr.Zero
+                                    ? System.Runtime.InteropServices.Marshal.PtrToStringUTF8(_descPtr) ?? "Unknown Swift error"
+                                    : "Unknown Swift error";
+                            }
+                            finally
+                            {
+                                if (_descPtr != IntPtr.Zero) {{hp}}SBW_Free(_descPtr);
+                            }
+                            var _typedErrorPtr = {{hp}}SBW_ExtractTypedError_{{typedErrorSafeSuffix}}(_errorPtr);
+                            if (_typedErrorPtr != IntPtr.Zero)
+                            {
+                                try
+                                {
+                                    var _typedError = ({{syncTypedErrorType}})SwiftMarshal.MarshalFromSwift<{{syncTypedErrorType}}>(_typedErrorPtr);
+                                    throw new SwiftException<{{syncTypedErrorType}}>(_typedError, _errorMessage);
+                                }
+                                finally
+                                {
+                                    {{hp}}SBW_Free(_typedErrorPtr);
+                                }
+                            }
+                            throw new SwiftException<{{syncTypedErrorType}}>(_errorMessage);
+                        }
+                        finally
+                        {
+                            {{hp}}SBW_ReleaseError(_errorPtr);
+                        }
+                    }
+                    """;
+            }
+        }
+        else
+        {
+            if (isCdeclConstructor)
+            {
+                // Untyped throws via @_cdecl out-pointer
+                errorCheckCode = $$"""
+                    if (errorPtr != IntPtr.Zero)
+                    {
+                        string _errorMessage;
+                        var _descPtr = {{hp}}SBW_GetErrorDescription(errorPtr);
+                        try
+                        {
+                            _errorMessage = _descPtr != IntPtr.Zero
+                                ? System.Runtime.InteropServices.Marshal.PtrToStringUTF8(_descPtr) ?? "Unknown Swift error"
+                                : "Unknown Swift error";
+                        }
+                        finally
+                        {
+                            if (_descPtr != IntPtr.Zero) {{hp}}SBW_Free(_descPtr);
+                            {{hp}}SBW_ReleaseError(errorPtr);
+                        }
+                        throw new SwiftRuntimeException(_errorMessage);
+                    }
+                    """;
+            }
+            else
+            {
+                // Untyped throws — extract message via SBW_GetErrorDescription, release via SBW_ReleaseError
+                errorCheckCode = $$"""
+                    if (swiftError.Value != null)
+                    {
+                        string _errorMessage;
+                        var _errorPtr = (IntPtr)swiftError.Value;
                         var _descPtr = {{hp}}SBW_GetErrorDescription(_errorPtr);
                         try
                         {
@@ -387,52 +516,12 @@ internal class MethodMarshalPlanBuilder
                         finally
                         {
                             if (_descPtr != IntPtr.Zero) {{hp}}SBW_Free(_descPtr);
+                            {{hp}}SBW_ReleaseError(_errorPtr);
                         }
-                        var _typedErrorPtr = {{hp}}SBW_ExtractTypedError_{{typedErrorSafeSuffix}}(_errorPtr);
-                        if (_typedErrorPtr != IntPtr.Zero)
-                        {
-                            try
-                            {
-                                var _typedError = ({{syncTypedErrorType}})SwiftMarshal.MarshalFromSwift<{{syncTypedErrorType}}>(_typedErrorPtr);
-                                throw new SwiftException<{{syncTypedErrorType}}>(_typedError, _errorMessage);
-                            }
-                            finally
-                            {
-                                {{hp}}SBW_Free(_typedErrorPtr);
-                            }
-                        }
-                        throw new SwiftException<{{syncTypedErrorType}}>(_errorMessage);
+                        throw new SwiftRuntimeException(_errorMessage);
                     }
-                    finally
-                    {
-                        {{hp}}SBW_ReleaseError(_errorPtr);
-                    }
-                }
-                """;
-        }
-        else
-        {
-            // Untyped throws — extract message via SBW_GetErrorDescription, release via SBW_ReleaseError
-            errorCheckCode = $$"""
-                if (swiftError.Value != null)
-                {
-                    string _errorMessage;
-                    var _errorPtr = (IntPtr)swiftError.Value;
-                    var _descPtr = {{hp}}SBW_GetErrorDescription(_errorPtr);
-                    try
-                    {
-                        _errorMessage = _descPtr != IntPtr.Zero
-                            ? System.Runtime.InteropServices.Marshal.PtrToStringUTF8(_descPtr) ?? "Unknown Swift error"
-                            : "Unknown Swift error";
-                    }
-                    finally
-                    {
-                        if (_descPtr != IntPtr.Zero) {{hp}}SBW_Free(_descPtr);
-                        {{hp}}SBW_ReleaseError(_errorPtr);
-                    }
-                    throw new SwiftRuntimeException(_errorMessage);
-                }
-                """;
+                    """;
+            }
         }
 
         return new SwiftErrorSetup

--- a/src/Swift.Bindings/src/Model/TypeDecl/MethodDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/MethodDecl.cs
@@ -196,6 +196,14 @@ namespace BindingsGeneration
         /// dispatch and are called via generated @_silgen_name Swift wrappers.
         /// </summary>
         public bool IsProtocolExtensionMethod { get; set; } = false;
+
+        /// <summary>
+        /// When true, this constructor uses a @_cdecl Swift wrapper with C calling convention
+        /// instead of CallConvSwift. Routes constructor P/Invokes through CallingConvention.Cdecl
+        /// to avoid NativeAOT/ARM64 ABI mismatches with struct parameters and indirect results.
+        /// Set by ConstructorWrapperEmitter before SignatureHandler construction.
+        /// </summary>
+        public bool UsesCdeclConstructorWrapper { get; set; } = false;
     }
 
     /// <summary>

--- a/src/Swift.Bindings/src/Parser/ModuleProcessor.cs
+++ b/src/Swift.Bindings/src/Parser/ModuleProcessor.cs
@@ -248,8 +248,13 @@ namespace BindingsGeneration
         {
             TypeRecordFlags flags = TypeRecordFlags.None;
 
+            // Non-copyable (~Copyable) types explicitly list Swift.Escapable in conformances.
+            // Normal types have both Copyable and Escapable implicitly (unlisted).
+            if (structDecl.Conformances.Any(c => c.Protocol.ToString() == "Swift.Escapable"))
+                flags |= TypeRecordFlags.NonCopyable;
+
             if (!structDecl.IsFrozen)
-                return TypeRecordFlags.None;
+                return flags;
 
             if (structDecl.IsFrozen)
                 flags |= TypeRecordFlags.Frozen;

--- a/src/Swift.Bindings/src/TypeDatabase/TypeDatabase.cs
+++ b/src/Swift.Bindings/src/TypeDatabase/TypeDatabase.cs
@@ -175,6 +175,7 @@ namespace BindingsGeneration
                 string classBound = typeDeclarationNode?.Attributes?["classBound"]?.Value ?? "false";
                 string objcRooted = typeDeclarationNode?.Attributes?["objcRooted"]?.Value ?? "false";
                 string hasMethodSelfTypeParams = typeDeclarationNode?.Attributes?["hasMethodSelfTypeParams"]?.Value ?? "false";
+                string nonCopyable = typeDeclarationNode?.Attributes?["nonCopyable"]?.Value ?? "false";
                 string? rawValueType = typeDeclarationNode?.Attributes?["rawValueType"]?.Value;
                 string? emittedMemberCountStr = typeDeclarationNode?.Attributes?["emittedMemberCount"]?.Value;
                 int? emittedMemberCount = emittedMemberCountStr != null ? int.Parse(emittedMemberCountStr) : null;
@@ -215,7 +216,8 @@ namespace BindingsGeneration
                             (inheritedRequirementsOnly.ToLower() == "true" ? TypeRecordFlags.InheritedRequirementsOnly : TypeRecordFlags.None) |
                             (classBound.ToLower() == "true" ? TypeRecordFlags.ClassBound : TypeRecordFlags.None) |
                             (objcRooted.ToLower() == "true" ? TypeRecordFlags.ObjCRooted : TypeRecordFlags.None) |
-                            (hasMethodSelfTypeParams.ToLower() == "true" ? TypeRecordFlags.HasMethodSelfTypeParams : TypeRecordFlags.None),
+                            (hasMethodSelfTypeParams.ToLower() == "true" ? TypeRecordFlags.HasMethodSelfTypeParams : TypeRecordFlags.None) |
+                            (nonCopyable.ToLower() == "true" ? TypeRecordFlags.NonCopyable : TypeRecordFlags.None),
                     Kind = kindStr.ToLower() switch
                     {
                         "class" => TypeRecordKind.Class,

--- a/src/Swift.Bindings/src/TypeDatabase/TypeRecord.cs
+++ b/src/Swift.Bindings/src/TypeDatabase/TypeRecord.cs
@@ -55,6 +55,10 @@ public enum TypeRecordFlags
     // for Self positions, making the constraint unsatisfiable by concrete types (CS0738).
     // Used to skip the constraint in generic where clauses and bound generic validation.
     HasMethodSelfTypeParams = 1 << 9,
+    // This flag indicates a struct is non-copyable (~Copyable). Non-copyable types explicitly
+    // list Swift.Escapable in their conformances (normal types have both Copyable and Escapable
+    // implicitly, unlisted). Used to skip @_cdecl constructor wrappers for cross-module params.
+    NonCopyable = 1 << 10,
 }
 
 /// <summary>

--- a/src/Swift.Bindings/tests/UnitTests/EmitterTests/ConstructorHandlerOutputTests.cs
+++ b/src/Swift.Bindings/tests/UnitTests/EmitterTests/ConstructorHandlerOutputTests.cs
@@ -276,6 +276,99 @@ public class ConstructorHandlerOutputTests
 
     #endregion
 
+    #region @_cdecl Constructor Wrapper Integration Tests
+
+    [Fact]
+    public void Emit_PrimaryConstructor_EmitsCdeclSwiftWrapper()
+    {
+        // Primary constructors (not default-param overloads) must also get @_cdecl wrappers.
+        // This was the core bug: ConstructorHandler was missing the wrapper emission logic.
+        var typeDatabase = CreateTypeDatabase();
+        typeDatabase.AsyncLibraryName = "TestModuleSwiftBindings";
+        var moduleDecl = CreateModuleDecl("TestModule");
+        var parentDecl = CreateFrozenStructDecl("Point", moduleDecl);
+        var constructor = CreateConstructorDecl("init", parentDecl, moduleDecl);
+
+        var (_, swiftOutput) = EmitConstructor(constructor, typeDatabase);
+
+        // Swift output should contain the @_cdecl wrapper
+        Assert.Contains("@_cdecl(\"", swiftOutput);
+        Assert.Contains("SBW_TestModule_Point_init_", swiftOutput);
+        Assert.Contains("resultPtr.assumingMemoryBound(to: TestModule.Point.self).initialize(to: result)", swiftOutput);
+    }
+
+    [Fact]
+    public void Emit_PrimaryClassConstructor_EmitsCdeclSwiftWrapper()
+    {
+        // Class constructors should also get @_cdecl wrappers that return pointers.
+        var typeDatabase = CreateTypeDatabase();
+        typeDatabase.AsyncLibraryName = "TestModuleSwiftBindings";
+        var moduleDecl = CreateModuleDecl("TestModule");
+        var parentDecl = CreateClassDecl("Animal", moduleDecl, typeDatabase);
+        var constructor = CreateConstructorDeclForClass("init", parentDecl, moduleDecl);
+
+        var (_, swiftOutput) = EmitConstructor(constructor, typeDatabase);
+
+        Assert.Contains("@_cdecl(\"", swiftOutput);
+        Assert.Contains("SBW_TestModule_Animal_init_", swiftOutput);
+        Assert.Contains("Unmanaged.passRetained(result).toOpaque()", swiftOutput);
+    }
+
+    [Fact]
+    public void Emit_PrimaryConstructorWithParam_CdeclWrapperIncludesParam()
+    {
+        var typeDatabase = CreateTypeDatabase();
+        typeDatabase.AsyncLibraryName = "TestModuleSwiftBindings";
+        var moduleDecl = CreateModuleDecl("TestModule");
+        var parentDecl = CreateFrozenStructDecl("Point", moduleDecl);
+        var constructor = CreateConstructorDecl("init", parentDecl, moduleDecl,
+            parameters: new List<ArgumentDecl>
+            {
+                CreateArgument("x", new NamedTypeSpec("Swift.Int"), moduleDecl)
+            });
+
+        var (_, swiftOutput) = EmitConstructor(constructor, typeDatabase);
+
+        Assert.Contains("@_cdecl(\"", swiftOutput);
+        Assert.Contains("_ x: Int", swiftOutput);
+    }
+
+    [Fact]
+    public void Emit_PrimaryConstructor_CSharpUsesCdeclCallingConvention()
+    {
+        // When @_cdecl wrapper is emitted, C# P/Invoke should NOT use CallConvSwift
+        var typeDatabase = CreateTypeDatabase();
+        typeDatabase.AsyncLibraryName = "TestModuleSwiftBindings";
+        var moduleDecl = CreateModuleDecl("TestModule");
+        var parentDecl = CreateFrozenStructDecl("Point", moduleDecl);
+        var constructor = CreateConstructorDecl("init", parentDecl, moduleDecl);
+
+        var (csOutput, _) = EmitConstructor(constructor, typeDatabase);
+
+        // With @_cdecl wrapper, the P/Invoke should reference the wrapper library
+        Assert.Contains("SBW_TestModule_Point_init_", csOutput);
+        // Should NOT have CallConvSwift — the wrapper uses C calling convention
+        Assert.DoesNotContain("CallConvSwift", csOutput);
+    }
+
+    [Fact]
+    public void Emit_PrimaryConstructor_NoAsyncLibrary_NoCdeclWrapper()
+    {
+        // Without xcframework mode (no AsyncLibraryName), no @_cdecl wrapper.
+        var typeDatabase = CreateTypeDatabase();
+        // AsyncLibraryName is null — not in xcframework mode
+        var moduleDecl = CreateModuleDecl("TestModule");
+        var parentDecl = CreateFrozenStructDecl("Point", moduleDecl);
+        var constructor = CreateConstructorDecl("init", parentDecl, moduleDecl);
+
+        var (_, swiftOutput) = EmitConstructor(constructor, typeDatabase);
+
+        Assert.DoesNotContain("@_cdecl(\"", swiftOutput);
+        Assert.DoesNotContain("SBW_", swiftOutput);
+    }
+
+    #endregion
+
     private static TypeDatabase CreateTypeDatabase()
     {
         var typeDatabase = new TypeDatabase();
@@ -599,7 +692,9 @@ public class ConstructorHandlerOutputTests
         var handler = new ConstructorHandler(new NullLogger<ConstructorHandler>(), new HashSet<string>());
         var env = new MethodEnvironment(methodDecl, typeDatabase);
         var conductor = new Conductor(new NullLoggerFactory());
-        handler.Emit(csWriter, swiftWriter, env, conductor, TypeHandlerContext.Empty);
+        // Use a fresh ModuleEmissionContext to avoid cross-test dedup via the shared Default singleton.
+        var context = new TypeHandlerContext(null, new(), null, EmissionContext: new ModuleEmissionContext());
+        handler.Emit(csWriter, swiftWriter, env, conductor, context);
 
         return (csOutput.ToString(), swiftOutput.ToString());
     }

--- a/src/Swift.Bindings/tests/UnitTests/EmitterTests/ConstructorWrapperEmitterTests.cs
+++ b/src/Swift.Bindings/tests/UnitTests/EmitterTests/ConstructorWrapperEmitterTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Justin Wojciechowski.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using Xunit;
 
 namespace BindingsGeneration.Tests;
@@ -141,6 +143,253 @@ public class ConstructorWrapperEmitterTests
         Assert.True(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
     }
 
+    [Fact]
+    public void ShouldEmitWrapper_NonCopyableStruct_ReturnsFalse()
+    {
+        // ~Copyable types explicitly list Swift.Escapable in their conformances.
+        // Defense-in-depth guard: skip non-copyable types even though assumingMemoryBound.initialize
+        // is ~Copyable-safe, because non-copyable types may have other ABI constraints.
+        var (moduleDecl, typeDb) = CreateTestEnvironment("UniqueResource");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateStructDecl("UniqueResource", moduleDecl);
+        parentDecl.Conformances = new List<TypeConformance>
+        {
+            new(SwiftTypeName.FromModuleQualifiedName("TestModule.UniqueResource"),
+                SwiftTypeName.FromModuleQualifiedName("Swift.Escapable"),
+                "$s10TestModule14UniqueResourceVACSWAAMc")
+        };
+        var method = CreateMethod("init", isConstructor: true, parentDecl, moduleDecl);
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.False(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    [Fact]
+    public void ShouldEmitWrapper_CopyableStruct_ReturnsTrue()
+    {
+        // Normal (Copyable) structs don't list Escapable explicitly — they should get wrappers.
+        var (moduleDecl, typeDb) = CreateTestEnvironment("NormalStruct");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateStructDecl("NormalStruct", moduleDecl);
+        // Empty conformances = Copyable (implicit)
+        var method = CreateMethod("init", isConstructor: true, parentDecl, moduleDecl);
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.True(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    [Fact]
+    public void ShouldEmitWrapper_NonCopyableStructParameter_ReturnsFalse()
+    {
+        // A copyable type with a non-copyable struct parameter must not get a @_cdecl wrapper.
+        // The wrapper passes frozen structs by value, which requires Copyable. C# also passes
+        // frozen structs by value, so there's no pointer-based fallback available.
+        var (moduleDecl, typeDb) = CreateTestEnvironment("Container");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        // Create the non-copyable struct type (with explicit Escapable conformance)
+        var nonCopyableDecl = CreateStructDecl("UniqueToken", moduleDecl);
+        nonCopyableDecl.Conformances = new List<TypeConformance>
+        {
+            new(SwiftTypeName.FromModuleQualifiedName("TestModule.UniqueToken"),
+                SwiftTypeName.FromModuleQualifiedName("Swift.Escapable"),
+                "$s10TestModule11UniqueTokenVACSWAAMc")
+        };
+
+        // Create a copyable parent type with a constructor taking the non-copyable param
+        var parentDecl = CreateStructDecl("Container", moduleDecl);
+        var method = new MethodDecl
+        {
+            Name = "init",
+            MangledName = "$s10TestModule9ContainerVyAcA11UniqueTokenVncfC",
+            MethodType = MethodType.Instance,
+            IsConstructor = true,
+            CSSignature = new List<ArgumentDecl>
+            {
+                CreateReturnArg(moduleDecl),
+                new ArgumentDecl
+                {
+                    Name = "token",
+                    PrivateName = "token",
+                    SwiftTypeSpec = new NamedTypeSpec("TestModule.UniqueToken"),
+                    IsInOut = false,
+                    IsGeneric = false,
+                    ParentDecl = null,
+                    ModuleDecl = moduleDecl
+                }
+            },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = false,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+        parentDecl.Methods.Add(method);
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.False(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    [Fact]
+    public void ShouldEmitWrapper_CopyableStructParameter_ReturnsTrue()
+    {
+        // A constructor with only copyable struct parameters should still get a wrapper.
+        var (moduleDecl, typeDb) = CreateTestEnvironment("Container");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        // Create a normal copyable struct parameter type
+        CreateStructDecl("Point", moduleDecl);
+
+        var parentDecl = CreateStructDecl("Container", moduleDecl);
+        var method = new MethodDecl
+        {
+            Name = "init",
+            MangledName = "$s10TestModule9ContainerVyAcA5PointVcfC",
+            MethodType = MethodType.Instance,
+            IsConstructor = true,
+            CSSignature = new List<ArgumentDecl>
+            {
+                CreateReturnArg(moduleDecl),
+                new ArgumentDecl
+                {
+                    Name = "point",
+                    PrivateName = "point",
+                    SwiftTypeSpec = new NamedTypeSpec("TestModule.Point"),
+                    IsInOut = false,
+                    IsGeneric = false,
+                    ParentDecl = null,
+                    ModuleDecl = moduleDecl
+                }
+            },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = false,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+        parentDecl.Methods.Add(method);
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.True(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    [Fact]
+    public void ShouldEmitWrapper_CrossModuleNonCopyableStructParameter_ReturnsFalse()
+    {
+        // A constructor parameter is a non-copyable struct from a DIFFERENT module.
+        // FindStructDecl won't find it in ModuleDecl.Types, so the guard must fall back
+        // to checking the NonCopyable flag on the TypeRecord in the TypeDatabase.
+        var (moduleDecl, typeDb) = CreateTestEnvironment("Container");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        // Register the cross-module non-copyable struct in a separate module database
+        var depModule = new ModuleTypeDatabase("DepModule", "/tmp/DepModule.dylib");
+        depModule.RegisterType(
+            SwiftTypeName.FromModuleQualifiedName("DepModule.UniqueHandle"),
+            new TypeRecord
+            {
+                CSharpTypeName = CSharpTypeName.FromNamespaceAndName("DepModule", "UniqueHandle"),
+                SwiftTypeName = SwiftTypeName.FromModuleQualifiedName("DepModule.UniqueHandle"),
+                MetadataAccessor = "$s9DepModule12UniqueHandleVMa",
+                Flags = TypeRecordFlags.Frozen | TypeRecordFlags.NonCopyable,
+                Kind = TypeRecordKind.Struct
+            });
+        typeDb.AddModuleDatabase(depModule);
+
+        // Note: UniqueHandle is NOT in moduleDecl.Types (it's cross-module)
+        var parentDecl = CreateStructDecl("Container", moduleDecl);
+        var method = new MethodDecl
+        {
+            Name = "init",
+            MangledName = "$s10TestModule9ContainerVyAc9DepModule12UniqueHandleVcfC",
+            MethodType = MethodType.Instance,
+            IsConstructor = true,
+            CSSignature = new List<ArgumentDecl>
+            {
+                CreateReturnArg(moduleDecl),
+                new ArgumentDecl
+                {
+                    Name = "handle",
+                    PrivateName = "handle",
+                    SwiftTypeSpec = new NamedTypeSpec("DepModule.UniqueHandle"),
+                    IsInOut = false,
+                    IsGeneric = false,
+                    ParentDecl = null,
+                    ModuleDecl = moduleDecl
+                }
+            },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = false,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+        parentDecl.Methods.Add(method);
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.False(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    [Fact]
+    public void ShouldEmitWrapper_CrossModuleCopyableStructParameter_ReturnsTrue()
+    {
+        // A constructor parameter is a normal copyable struct from a different module.
+        // The TypeRecord exists but does NOT have the NonCopyable flag — should get a wrapper.
+        var (moduleDecl, typeDb) = CreateTestEnvironment("Container");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var depModule = new ModuleTypeDatabase("DepModule", "/tmp/DepModule.dylib");
+        depModule.RegisterType(
+            SwiftTypeName.FromModuleQualifiedName("DepModule.Config"),
+            new TypeRecord
+            {
+                CSharpTypeName = CSharpTypeName.FromNamespaceAndName("DepModule", "Config"),
+                SwiftTypeName = SwiftTypeName.FromModuleQualifiedName("DepModule.Config"),
+                MetadataAccessor = "$s9DepModule6ConfigVMa",
+                Flags = TypeRecordFlags.Frozen,
+                Kind = TypeRecordKind.Struct
+            });
+        typeDb.AddModuleDatabase(depModule);
+
+        var parentDecl = CreateStructDecl("Container", moduleDecl);
+        var method = new MethodDecl
+        {
+            Name = "init",
+            MangledName = "$s10TestModule9ContainerVyAc9DepModule6ConfigVcfC",
+            MethodType = MethodType.Instance,
+            IsConstructor = true,
+            CSSignature = new List<ArgumentDecl>
+            {
+                CreateReturnArg(moduleDecl),
+                new ArgumentDecl
+                {
+                    Name = "config",
+                    PrivateName = "config",
+                    SwiftTypeSpec = new NamedTypeSpec("DepModule.Config"),
+                    IsInOut = false,
+                    IsGeneric = false,
+                    ParentDecl = null,
+                    ModuleDecl = moduleDecl
+                }
+            },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = false,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+        parentDecl.Methods.Add(method);
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.True(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
     #endregion
 
     #region Symbol Naming Tests
@@ -197,7 +446,7 @@ public class ConstructorWrapperEmitterTests
         var output = sw.ToString();
         Assert.Contains("@_cdecl(\"", output);
         Assert.Contains("_ resultPtr: UnsafeMutableRawPointer", output);
-        Assert.Contains("resultPtr.initializeMemory(as: TestModule.MyStruct.self", output);
+        Assert.Contains("resultPtr.assumingMemoryBound(to: TestModule.MyStruct.self).initialize(to: result)", output);
         Assert.DoesNotContain("errorOut", output);
     }
 
@@ -360,6 +609,221 @@ public class ConstructorWrapperEmitterTests
         var output = sw.ToString();
         Assert.Contains("TestModule.TypeA", output);
         Assert.Contains("TestModule.TypeB", output);
+    }
+
+    #endregion
+
+    #region @MainActor Annotation Tests
+
+    [Fact]
+    public void EmitSwiftWrapper_MainActorIsolated_EmitsMainActorAnnotation()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: false, isFailable: false, throws: false);
+        var parentDecl = env.ParentDecl as TypeDecl;
+        parentDecl!.IsMainActorIsolated = true;
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("@MainActor", output);
+        Assert.Contains("@_cdecl(\"", output);
+    }
+
+    [Fact]
+    public void EmitSwiftWrapper_NotMainActorIsolated_NoMainActorAnnotation()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: false, isFailable: false, throws: false);
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.DoesNotContain("@MainActor", output);
+        Assert.Contains("@_cdecl(\"", output);
+    }
+
+    #endregion
+
+    #region Frozen/Non-Frozen Struct Parameter Tests
+
+    [Fact]
+    public void EmitSwiftWrapper_WithFrozenStructParam_PassesByValue()
+    {
+        // Frozen structs are passed by value from C# (Buffer or blittable),
+        // so the @_cdecl wrapper must accept the Swift type directly.
+        var (moduleDecl, typeDb) = CreateTestEnvironmentWithExtraTypes(
+            "Container",
+            ("TestModule.Point", TypeRecordFlags.Frozen, TypeRecordKind.Struct));
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateClassDecl("Container", moduleDecl);
+        var method = new MethodDecl
+        {
+            Name = "init",
+            MangledName = "$s10TestModule9ContainerCyAcA5PointVcfC",
+            MethodType = MethodType.Instance,
+            IsConstructor = true,
+            CSSignature = new List<ArgumentDecl>
+            {
+                CreateReturnArg(moduleDecl),
+                new ArgumentDecl
+                {
+                    Name = "point",
+                    PrivateName = "point",
+                    SwiftTypeSpec = new NamedTypeSpec("TestModule.Point"),
+                    IsInOut = false,
+                    IsGeneric = false,
+                    ParentDecl = null,
+                    ModuleDecl = moduleDecl
+                }
+            },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = false,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+
+        var cdeclSymbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+            "TestModule", "Container", method.MangledName);
+        method.MangledName = cdeclSymbol;
+        method.UsesCdeclConstructorWrapper = true;
+
+        var env = new MethodEnvironment(method, typeDb);
+        var ctx = new ModuleEmissionContext();
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        // Frozen struct: passed by value (Swift type name), NOT as UnsafeRawPointer
+        // RenderSwiftTypeSpec may use unqualified name "Point" or qualified "TestModule.Point"
+        Assert.Contains("_ point: ", output);
+        Assert.Contains("Point", output);
+        Assert.DoesNotContain("UnsafeRawPointer", output);
+        Assert.Contains("point: point", output);
+    }
+
+    [Fact]
+    public void EmitSwiftWrapper_WithNonFrozenStructParam_PassesAsPointer()
+    {
+        // Non-frozen structs are passed as SafeHandle (IntPtr) from C#,
+        // so the @_cdecl wrapper receives them as UnsafeRawPointer and loads.
+        var (moduleDecl, typeDb) = CreateTestEnvironmentWithExtraTypes(
+            "Container",
+            ("TestModule.Config", TypeRecordFlags.None, TypeRecordKind.Struct));
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateClassDecl("Container", moduleDecl);
+        var method = new MethodDecl
+        {
+            Name = "init",
+            MangledName = "$s10TestModule9ContainerCyAcA6ConfigVcfC",
+            MethodType = MethodType.Instance,
+            IsConstructor = true,
+            CSSignature = new List<ArgumentDecl>
+            {
+                CreateReturnArg(moduleDecl),
+                new ArgumentDecl
+                {
+                    Name = "config",
+                    PrivateName = "config",
+                    SwiftTypeSpec = new NamedTypeSpec("TestModule.Config"),
+                    IsInOut = false,
+                    IsGeneric = false,
+                    ParentDecl = null,
+                    ModuleDecl = moduleDecl
+                }
+            },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = false,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+
+        var cdeclSymbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+            "TestModule", "Container", method.MangledName);
+        method.MangledName = cdeclSymbol;
+        method.UsesCdeclConstructorWrapper = true;
+
+        var env = new MethodEnvironment(method, typeDb);
+        var ctx = new ModuleEmissionContext();
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        // Non-frozen struct: passed as pointer, needs load
+        Assert.Contains("_ config: UnsafeRawPointer", output);
+        Assert.Contains("config.load(as: Config.self)", output);
+    }
+
+    #endregion
+
+    #region Enum Raw Value Type Mapping Tests
+
+    [Fact]
+    public void EmitSwiftWrapper_WithEnumParam_UnqualifiedRawValueType_EmitsCorrectSwiftType()
+    {
+        // ABI JSON uses unqualified names like "Int32" not "Swift.Int32".
+        // GetSwiftRawValueType must handle both forms.
+        var (moduleDecl, typeDb) = CreateTestEnvironmentWithExtraTypes(
+            "Widget",
+            ("TestModule.Priority", TypeRecordFlags.Frozen | TypeRecordFlags.SimpleEnum, TypeRecordKind.Enum, "Int32"));
+
+        var parentDecl = CreateStructDecl("Widget", moduleDecl);
+        var method = new MethodDecl
+        {
+            Name = "init",
+            MangledName = "$s10TestModule6WidgetVyAcA8PriorityOcfC",
+            MethodType = MethodType.Instance,
+            IsConstructor = true,
+            CSSignature = new List<ArgumentDecl>
+            {
+                CreateReturnArg(moduleDecl),
+                new ArgumentDecl
+                {
+                    Name = "priority",
+                    PrivateName = "priority",
+                    SwiftTypeSpec = new NamedTypeSpec("TestModule.Priority"),
+                    IsInOut = false,
+                    IsGeneric = false,
+                    ParentDecl = null,
+                    ModuleDecl = moduleDecl
+                }
+            },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = false,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+
+        var cdeclSymbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+            "TestModule", "Widget", method.MangledName);
+        method.MangledName = cdeclSymbol;
+        method.UsesCdeclConstructorWrapper = true;
+
+        var env = new MethodEnvironment(method, typeDb);
+        var ctx = new ModuleEmissionContext();
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        // Should emit "Int32" (the correct Swift type), NOT "Int" (the fallback)
+        Assert.Contains("_ priority: Int32", output);
+        Assert.Contains("Priority(rawValue: priority)!", output);
     }
 
     #endregion
@@ -640,6 +1104,96 @@ public class ConstructorWrapperEmitterTests
         };
 
         return (moduleDecl, typeDb);
+    }
+
+    /// <summary>
+    /// Creates a test environment with additional types registered in the TestModule.
+    /// Used when constructor parameters need resolvable TypeRecords.
+    /// </summary>
+    private static (ModuleDecl moduleDecl, TypeDatabase typeDb) CreateTestEnvironmentWithExtraTypes(
+        string typeName,
+        params (string qualifiedName, TypeRecordFlags flags, TypeRecordKind kind, string? rawValueTypeName)[] extraTypes)
+    {
+        var typeDb = new TypeDatabase();
+
+        var swiftModule = new ModuleTypeDatabase("Swift", "/usr/lib/swift/libswiftCore.dylib");
+        swiftModule.RegisterType(
+            SwiftTypeName.FromModuleQualifiedName("Swift.Int"),
+            new TypeRecord
+            {
+                CSharpTypeName = CSharpTypeName.FromNamespaceAndName("System", "Int64"),
+                SwiftTypeName = SwiftTypeName.FromModuleQualifiedName("Swift.Int"),
+                MetadataAccessor = "$sSiMa",
+                Flags = TypeRecordFlags.Frozen,
+                Kind = TypeRecordKind.Struct
+            });
+        swiftModule.RegisterType(
+            SwiftTypeName.FromModuleQualifiedName("Swift.Bool"),
+            new TypeRecord
+            {
+                CSharpTypeName = CSharpTypeName.FromNamespaceAndName("System", "Boolean"),
+                SwiftTypeName = SwiftTypeName.FromModuleQualifiedName("Swift.Bool"),
+                MetadataAccessor = "$sSbMa",
+                Flags = TypeRecordFlags.Frozen,
+                Kind = TypeRecordKind.Struct
+            });
+        typeDb.AddModuleDatabase(swiftModule);
+
+        var testModule = new ModuleTypeDatabase("TestModule", "/tmp/TestModule.dylib");
+        testModule.RegisterType(
+            SwiftTypeName.FromModuleQualifiedName($"TestModule.{typeName}"),
+            new TypeRecord
+            {
+                CSharpTypeName = CSharpTypeName.FromNamespaceAndName("TestModule", typeName),
+                SwiftTypeName = SwiftTypeName.FromModuleQualifiedName($"TestModule.{typeName}"),
+                MetadataAccessor = $"$s10TestModule{typeName.Length}{typeName}VMa",
+                Flags = TypeRecordFlags.Frozen,
+                Kind = TypeRecordKind.Struct
+            });
+
+        foreach (var (qualifiedName, flags, kind, rawValue) in extraTypes)
+        {
+            var swiftTypeName = SwiftTypeName.FromModuleQualifiedName(qualifiedName);
+            testModule.RegisterType(
+                swiftTypeName,
+                new TypeRecord
+                {
+                    CSharpTypeName = CSharpTypeName.FromNamespaceAndName("TestModule", swiftTypeName.Name),
+                    SwiftTypeName = swiftTypeName,
+                    MetadataAccessor = $"$s{swiftTypeName.Name}Ma",
+                    Flags = flags,
+                    Kind = kind,
+                    RawValueTypeName = rawValue
+                });
+        }
+
+        typeDb.AddModuleDatabase(testModule);
+
+        var moduleDecl = new ModuleDecl
+        {
+            Name = "TestModule",
+            Properties = new List<PropertyDecl>(),
+            Methods = new List<MethodDecl>(),
+            Types = new List<TypeDecl>(),
+            Dependencies = new List<string>(),
+            Protocols = new List<ProtocolDecl>(),
+            ParentDecl = null,
+            ModuleDecl = null
+        };
+
+        return (moduleDecl, typeDb);
+    }
+
+    /// <summary>
+    /// Overload without rawValueTypeName for convenience.
+    /// </summary>
+    private static (ModuleDecl moduleDecl, TypeDatabase typeDb) CreateTestEnvironmentWithExtraTypes(
+        string typeName,
+        params (string qualifiedName, TypeRecordFlags flags, TypeRecordKind kind)[] extraTypes)
+    {
+        return CreateTestEnvironmentWithExtraTypes(
+            typeName,
+            extraTypes.Select(t => (t.qualifiedName, t.flags, t.kind, (string?)null)).ToArray());
     }
 
     /// <summary>

--- a/src/Swift.Bindings/tests/UnitTests/EmitterTests/ConstructorWrapperEmitterTests.cs
+++ b/src/Swift.Bindings/tests/UnitTests/EmitterTests/ConstructorWrapperEmitterTests.cs
@@ -1,0 +1,692 @@
+// Copyright (c) 2026 Justin Wojciechowski.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace BindingsGeneration.Tests;
+
+/// <summary>
+/// Tests for ConstructorWrapperEmitter: per-constructor @_cdecl wrappers that route
+/// constructor P/Invokes through C calling convention to avoid CallConvSwift crashes on NativeAOT.
+/// </summary>
+public class ConstructorWrapperEmitterTests
+{
+    #region ShouldEmitWrapper Guard Tests
+
+    [Fact]
+    public void ShouldEmitWrapper_NonConstructor_ReturnsFalse()
+    {
+        var (moduleDecl, typeDb) = CreateTestEnvironment("MyType");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateStructDecl("MyType", moduleDecl);
+        var method = CreateMethod("doSomething", isConstructor: false, parentDecl, moduleDecl);
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.False(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    [Fact]
+    public void ShouldEmitWrapper_NoAsyncLibraryName_ReturnsFalse()
+    {
+        var (moduleDecl, typeDb) = CreateTestEnvironment("MyType");
+        // AsyncLibraryName is null — not in xcframework mode
+
+        var parentDecl = CreateStructDecl("MyType", moduleDecl);
+        var method = CreateMethod("init", isConstructor: true, parentDecl, moduleDecl);
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.False(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    [Fact]
+    public void ShouldEmitWrapper_GenericParent_ReturnsFalse()
+    {
+        var (moduleDecl, typeDb) = CreateTestEnvironment("GenericBox");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateStructDecl("GenericBox", moduleDecl);
+        parentDecl.GenericParameters = new List<GenericArgumentDecl>
+        {
+            new("T", "T", new List<GenericParameterConformance>(), new List<GenericParameterConformance>())
+        };
+        var method = CreateMethod("init", isConstructor: true, parentDecl, moduleDecl);
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.False(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    [Fact]
+    public void ShouldEmitWrapper_AsyncConstructor_ReturnsFalse()
+    {
+        var (moduleDecl, typeDb) = CreateTestEnvironment("MyType");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateStructDecl("MyType", moduleDecl);
+        var method = CreateMethod("init", isConstructor: true, parentDecl, moduleDecl);
+        method.IsAsync = true;
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.False(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    [Fact]
+    public void ShouldEmitWrapper_ClosureParam_ReturnsFalse()
+    {
+        var (moduleDecl, typeDb) = CreateTestEnvironment("MyType");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateStructDecl("MyType", moduleDecl);
+
+        var closureType = new ClosureTypeSpec(
+            new TupleTypeSpec(new[] { new NamedTypeSpec("Swift.Int") }),
+            TupleTypeSpec.Empty);
+        closureType.Attributes.Add(new TypeSpecAttribute("escaping"));
+
+        var method = new MethodDecl
+        {
+            Name = "init",
+            MangledName = "$s10TestModule6MyTypeVySiyccfC",
+            MethodType = MethodType.Instance,
+            IsConstructor = true,
+            CSSignature = new List<ArgumentDecl>
+            {
+                CreateReturnArg(moduleDecl),
+                new ArgumentDecl
+                {
+                    Name = "handler",
+                    PrivateName = "handler",
+                    SwiftTypeSpec = closureType,
+                    IsInOut = false,
+                    IsGeneric = false,
+                    ParentDecl = null,
+                    ModuleDecl = moduleDecl
+                }
+            },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = false,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.False(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    [Fact]
+    public void ShouldEmitWrapper_ValidConstructor_ReturnsTrue()
+    {
+        var (moduleDecl, typeDb) = CreateTestEnvironment("MyType");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateStructDecl("MyType", moduleDecl);
+        var method = CreateMethod("init", isConstructor: true, parentDecl, moduleDecl);
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.True(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    [Fact]
+    public void ShouldEmitWrapper_ClassConstructor_ReturnsTrue()
+    {
+        var (moduleDecl, typeDb) = CreateTestEnvironment("Animal");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateClassDecl("Animal", moduleDecl);
+        var method = CreateMethod("init", isConstructor: true, parentDecl, moduleDecl);
+
+        var env = new MethodEnvironment(method, typeDb);
+        Assert.True(ConstructorWrapperEmitter.ShouldEmitWrapper(env));
+    }
+
+    #endregion
+
+    #region Symbol Naming Tests
+
+    [Fact]
+    public void GetConstructorSymbolName_SimpleType()
+    {
+        var symbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+            "Nuke", "ImageRequest", "$s4Nuke12ImageRequestVACycfC");
+        Assert.StartsWith("SBW_Nuke_ImageRequest_init_", symbol);
+    }
+
+    [Fact]
+    public void GetConstructorSymbolName_NestedType_DotReplacedWithUnderscore()
+    {
+        var symbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+            "Nuke", "ImageRequest.Priority", "$s4Nuke12ImageRequest8PriorityVACycfC");
+        Assert.Contains("SBW_Nuke_ImageRequest_Priority_init_", symbol);
+        Assert.DoesNotContain(".", symbol);
+    }
+
+    [Fact]
+    public void GetConstructorSymbolName_DifferentMangledNames_DifferentSymbols()
+    {
+        var symbol1 = ConstructorWrapperEmitter.GetConstructorSymbolName(
+            "TestModule", "Counter", "$s10TestModule7CounterVySicfC");
+        var symbol2 = ConstructorWrapperEmitter.GetConstructorSymbolName(
+            "TestModule", "Counter", "$s10TestModule7CounterVySiSicfC");
+        Assert.NotEqual(symbol1, symbol2);
+    }
+
+    [Fact]
+    public void GetConstructorSymbolName_SameMangledName_SameSymbol()
+    {
+        var mangled = "$s10TestModule7CounterVySicfC";
+        var symbol1 = ConstructorWrapperEmitter.GetConstructorSymbolName("TestModule", "Counter", mangled);
+        var symbol2 = ConstructorWrapperEmitter.GetConstructorSymbolName("TestModule", "Counter", mangled);
+        Assert.Equal(symbol1, symbol2);
+    }
+
+    #endregion
+
+    #region Swift Emission Tests — Struct Constructors
+
+    [Fact]
+    public void EmitSwiftWrapper_NonFailableStruct_EmitsCorrectBody()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: false, isFailable: false, throws: false);
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("@_cdecl(\"", output);
+        Assert.Contains("_ resultPtr: UnsafeMutableRawPointer", output);
+        Assert.Contains("resultPtr.initializeMemory(as: TestModule.MyStruct.self", output);
+        Assert.DoesNotContain("errorOut", output);
+    }
+
+    [Fact]
+    public void EmitSwiftWrapper_FailableStruct_EmitsOptionalResult()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: false, isFailable: true, throws: false);
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("_ resultPtr: UnsafeMutableRawPointer", output);
+        Assert.Contains("Optional<TestModule.MyStruct>.self", output);
+    }
+
+    [Fact]
+    public void EmitSwiftWrapper_ThrowingStruct_EmitsDoTryCatch()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: false, isFailable: false, throws: true);
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("_ resultPtr: UnsafeMutableRawPointer", output);
+        Assert.Contains("_ errorOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>", output);
+        Assert.Contains("do {", output);
+        Assert.Contains("try", output);
+        Assert.Contains("} catch {", output);
+        Assert.Contains("errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()", output);
+    }
+
+    [Fact]
+    public void EmitSwiftWrapper_FailableThrowingStruct_EmitsOptionalDoTryCatch()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: false, isFailable: true, throws: true);
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("_ resultPtr: UnsafeMutableRawPointer", output);
+        Assert.Contains("_ errorOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>", output);
+        Assert.Contains("Optional<TestModule.MyStruct>.self", output);
+        Assert.Contains("errorOut.pointee", output);
+    }
+
+    #endregion
+
+    #region Swift Emission Tests — Class Constructors
+
+    [Fact]
+    public void EmitSwiftWrapper_NonFailableClass_ReturnsPointer()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: true, isFailable: false, throws: false);
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("-> UnsafeMutableRawPointer", output);
+        Assert.Contains("Unmanaged.passRetained(result).toOpaque()", output);
+        Assert.DoesNotContain("resultPtr", output);
+    }
+
+    [Fact]
+    public void EmitSwiftWrapper_FailableClass_ReturnsNullablePointer()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: true, isFailable: true, throws: false);
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("-> UnsafeMutableRawPointer?", output);
+        Assert.Contains("guard let result =", output);
+        Assert.Contains("return nil", output);
+        Assert.Contains("Unmanaged.passRetained(result).toOpaque()", output);
+    }
+
+    [Fact]
+    public void EmitSwiftWrapper_ThrowingClass_EmitsDoTryCatch()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: true, isFailable: false, throws: true);
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("-> UnsafeMutableRawPointer", output);
+        Assert.Contains("_ errorOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>", output);
+        Assert.Contains("do {", output);
+        Assert.Contains("let result = try", output);
+        Assert.Contains("Unmanaged.passRetained(result).toOpaque()", output);
+        Assert.Contains("errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()", output);
+        // Must use bitPattern: 1 (non-nil sentinel), NOT bitPattern: 0 which traps on force-unwrap
+        Assert.Contains("UnsafeMutableRawPointer(bitPattern: 1)!", output);
+        Assert.DoesNotContain("bitPattern: 0", output);
+    }
+
+    [Fact]
+    public void EmitSwiftWrapper_FailableThrowingClass_EmitsGuardAndCatch()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: true, isFailable: true, throws: true);
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("-> UnsafeMutableRawPointer?", output);
+        Assert.Contains("guard let result = try", output);
+        Assert.Contains("return nil", output);
+        Assert.Contains("errorOut.pointee", output);
+    }
+
+    #endregion
+
+    #region Deduplication Tests
+
+    [Fact]
+    public void EmitSwiftWrapper_SecondCallSameSymbol_DoesNotEmit()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: false, isFailable: false, throws: false);
+
+        var sw1 = new StringWriter();
+        var writer1 = new SwiftWriter(sw1);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer1, env, ctx);
+        Assert.NotEmpty(sw1.ToString());
+
+        // Second call with same context — should be deduped
+        var sw2 = new StringWriter();
+        var writer2 = new SwiftWriter(sw2);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer2, env, ctx);
+        Assert.Empty(sw2.ToString());
+    }
+
+    [Fact]
+    public void EmitSwiftWrapper_DifferentSymbols_EmitsBoth()
+    {
+        var ctx = new ModuleEmissionContext();
+
+        var (env1, _) = CreateConstructorEnv(isClass: false, isFailable: false, throws: false,
+            typeName: "TypeA", mangledName: "$s10TestModule5TypeAVycfC");
+        var (env2, _) = CreateConstructorEnv(isClass: false, isFailable: false, throws: false,
+            typeName: "TypeB", mangledName: "$s10TestModule5TypeBVycfC");
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env1, ctx);
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env2, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("TestModule.TypeA", output);
+        Assert.Contains("TestModule.TypeB", output);
+    }
+
+    #endregion
+
+    #region Parameter Mapping Tests
+
+    [Fact]
+    public void EmitSwiftWrapper_WithIntParam_PassesThrough()
+    {
+        var (moduleDecl, typeDb) = CreateTestEnvironment("MyStruct");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateStructDecl("MyStruct", moduleDecl);
+        var method = new MethodDecl
+        {
+            Name = "init",
+            MangledName = "$s10TestModule8MyStructVySicfC",
+            MethodType = MethodType.Instance,
+            IsConstructor = true,
+            CSSignature = new List<ArgumentDecl>
+            {
+                CreateReturnArg(moduleDecl),
+                new ArgumentDecl
+                {
+                    Name = "value",
+                    PrivateName = "value",
+                    SwiftTypeSpec = new NamedTypeSpec("Swift.Int"),
+                    IsInOut = false,
+                    IsGeneric = false,
+                    ParentDecl = null,
+                    ModuleDecl = moduleDecl
+                }
+            },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = false,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+
+        // Set the mangled name to the cdecl symbol (as MethodHandler would do)
+        var cdeclSymbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+            "TestModule", "MyStruct", method.MangledName);
+        method.MangledName = cdeclSymbol;
+
+        var env = new MethodEnvironment(method, typeDb);
+        var ctx = new ModuleEmissionContext();
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("_ value: Int", output);
+        Assert.Contains("value: value", output);
+    }
+
+    [Fact]
+    public void EmitSwiftWrapper_WithBoolParam_EmitsInt8Conversion()
+    {
+        var (moduleDecl, typeDb) = CreateTestEnvironment("MyStruct");
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        var parentDecl = CreateStructDecl("MyStruct", moduleDecl);
+        var method = new MethodDecl
+        {
+            Name = "init",
+            MangledName = "$s10TestModule8MyStructVySbcfC",
+            MethodType = MethodType.Instance,
+            IsConstructor = true,
+            CSSignature = new List<ArgumentDecl>
+            {
+                CreateReturnArg(moduleDecl),
+                new ArgumentDecl
+                {
+                    Name = "flag",
+                    PrivateName = "flag",
+                    SwiftTypeSpec = new NamedTypeSpec("Swift.Bool"),
+                    IsInOut = false,
+                    IsGeneric = false,
+                    ParentDecl = null,
+                    ModuleDecl = moduleDecl
+                }
+            },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = false,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+
+        var cdeclSymbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+            "TestModule", "MyStruct", method.MangledName);
+        method.MangledName = cdeclSymbol;
+
+        var env = new MethodEnvironment(method, typeDb);
+        var ctx = new ModuleEmissionContext();
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(writer, env, ctx);
+
+        var output = sw.ToString();
+        Assert.Contains("_ flag: Int8", output);
+        Assert.Contains("flagVal = flag != 0", output);
+    }
+
+    [Fact]
+    public void EmitSwiftWrapper_WithSilgenTarget_CallsSilgenFunction()
+    {
+        var (env, ctx) = CreateConstructorEnv(isClass: false, isFailable: false, throws: false);
+
+        var sw = new StringWriter();
+        var writer = new SwiftWriter(sw);
+
+        ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(
+            writer, env, ctx, silgenTarget: "_dbw_init_ABCD1234_1");
+
+        var output = sw.ToString();
+        Assert.Contains("_dbw_init_ABCD1234_1", output);
+        Assert.Contains("TestModule.MyStruct._dbw_init_ABCD1234_1(", output);
+    }
+
+    #endregion
+
+    #region ModuleEmissionContext Tracking Tests
+
+    [Fact]
+    public void ModuleEmissionContext_TracksConstructorWrapperSymbols()
+    {
+        var ctx = new ModuleEmissionContext();
+        var symbol = "SBW_TestModule_MyStruct_init_ABCD1234";
+
+        Assert.False(ctx.HasConstructorWrapperSymbol(symbol));
+
+        Assert.True(ctx.TryAddConstructorWrapperSymbol(symbol));
+        Assert.True(ctx.HasConstructorWrapperSymbol(symbol));
+
+        // Second add returns false (already tracked)
+        Assert.False(ctx.TryAddConstructorWrapperSymbol(symbol));
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static ArgumentDecl CreateReturnArg(ModuleDecl moduleDecl)
+    {
+        return new ArgumentDecl
+        {
+            Name = "",
+            PrivateName = "",
+            SwiftTypeSpec = TupleTypeSpec.Empty,
+            HasDefaultArg = false,
+            IsInOut = false,
+            IsGeneric = false,
+            ParentDecl = null,
+            ModuleDecl = moduleDecl
+        };
+    }
+
+    private static StructDecl CreateStructDecl(string name, ModuleDecl moduleDecl)
+    {
+        var decl = new StructDecl
+        {
+            Name = name,
+            SwiftTypeName = SwiftTypeName.FromModuleQualifiedName($"TestModule.{name}"),
+            MangledName = $"$s10TestModule{name.Length}{name}VN",
+            Properties = new List<PropertyDecl>(),
+            Methods = new List<MethodDecl>(),
+            Types = new List<TypeDecl>(),
+            Operators = new List<OperatorDecl>(),
+            Subscripts = new List<SubscriptDecl>(),
+            GenericParameters = new List<GenericArgumentDecl>(),
+            Conformances = new List<TypeConformance>(),
+            ParentDecl = moduleDecl,
+            ModuleDecl = moduleDecl,
+            IsFrozen = true,
+            MetadataAccessor = "$sMa"
+        };
+        moduleDecl.Types.Add(decl);
+        return decl;
+    }
+
+    private static ClassDecl CreateClassDecl(string name, ModuleDecl moduleDecl)
+    {
+        var decl = new ClassDecl
+        {
+            Name = name,
+            SwiftTypeName = SwiftTypeName.FromModuleQualifiedName($"TestModule.{name}"),
+            MangledName = $"$s10TestModule{name.Length}{name}CN",
+            Properties = new List<PropertyDecl>(),
+            Methods = new List<MethodDecl>(),
+            Types = new List<TypeDecl>(),
+            Operators = new List<OperatorDecl>(),
+            Subscripts = new List<SubscriptDecl>(),
+            GenericParameters = new List<GenericArgumentDecl>(),
+            Conformances = new List<TypeConformance>(),
+            ParentDecl = moduleDecl,
+            ModuleDecl = moduleDecl
+        };
+        moduleDecl.Types.Add(decl);
+        return decl;
+    }
+
+    private static MethodDecl CreateMethod(string name, bool isConstructor, TypeDecl parentDecl, ModuleDecl moduleDecl)
+    {
+        var method = new MethodDecl
+        {
+            Name = name,
+            MangledName = $"$s10TestModule{parentDecl.Name.Length}{parentDecl.Name}VycfC",
+            MethodType = MethodType.Instance,
+            IsConstructor = isConstructor,
+            CSSignature = new List<ArgumentDecl> { CreateReturnArg(moduleDecl) },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = false,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+        parentDecl.Methods.Add(method);
+        return method;
+    }
+
+    private static (ModuleDecl moduleDecl, TypeDatabase typeDb) CreateTestEnvironment(string typeName)
+    {
+        var typeDb = new TypeDatabase();
+
+        var swiftModule = new ModuleTypeDatabase("Swift", "/usr/lib/swift/libswiftCore.dylib");
+        swiftModule.RegisterType(
+            SwiftTypeName.FromModuleQualifiedName("Swift.Int"),
+            new TypeRecord
+            {
+                CSharpTypeName = CSharpTypeName.FromNamespaceAndName("System", "Int64"),
+                SwiftTypeName = SwiftTypeName.FromModuleQualifiedName("Swift.Int"),
+                MetadataAccessor = "$sSiMa",
+                Flags = TypeRecordFlags.Frozen,
+                Kind = TypeRecordKind.Struct
+            });
+        swiftModule.RegisterType(
+            SwiftTypeName.FromModuleQualifiedName("Swift.Bool"),
+            new TypeRecord
+            {
+                CSharpTypeName = CSharpTypeName.FromNamespaceAndName("System", "Boolean"),
+                SwiftTypeName = SwiftTypeName.FromModuleQualifiedName("Swift.Bool"),
+                MetadataAccessor = "$sSbMa",
+                Flags = TypeRecordFlags.Frozen,
+                Kind = TypeRecordKind.Struct
+            });
+        typeDb.AddModuleDatabase(swiftModule);
+
+        var testModule = new ModuleTypeDatabase("TestModule", "/tmp/TestModule.dylib");
+        testModule.RegisterType(
+            SwiftTypeName.FromModuleQualifiedName($"TestModule.{typeName}"),
+            new TypeRecord
+            {
+                CSharpTypeName = CSharpTypeName.FromNamespaceAndName("TestModule", typeName),
+                SwiftTypeName = SwiftTypeName.FromModuleQualifiedName($"TestModule.{typeName}"),
+                MetadataAccessor = $"$s10TestModule{typeName.Length}{typeName}VMa",
+                Flags = TypeRecordFlags.Frozen,
+                Kind = TypeRecordKind.Struct
+            });
+        typeDb.AddModuleDatabase(testModule);
+
+        var moduleDecl = new ModuleDecl
+        {
+            Name = "TestModule",
+            Properties = new List<PropertyDecl>(),
+            Methods = new List<MethodDecl>(),
+            Types = new List<TypeDecl>(),
+            Dependencies = new List<string>(),
+            Protocols = new List<ProtocolDecl>(),
+            ParentDecl = null,
+            ModuleDecl = null
+        };
+
+        return (moduleDecl, typeDb);
+    }
+
+    /// <summary>
+    /// Creates a constructor MethodEnvironment for emission tests.
+    /// Sets up the MangledName to the cdecl symbol as MethodHandler would.
+    /// </summary>
+    private static (MethodEnvironment env, ModuleEmissionContext ctx) CreateConstructorEnv(
+        bool isClass, bool isFailable, bool throws,
+        string typeName = "MyStruct", string mangledName = "")
+    {
+        var (moduleDecl, typeDb) = CreateTestEnvironment(typeName);
+        typeDb.AsyncLibraryName = "TestModuleSwiftBindings";
+
+        TypeDecl parentDecl = isClass
+            ? CreateClassDecl(typeName, moduleDecl)
+            : CreateStructDecl(typeName, moduleDecl);
+
+        if (string.IsNullOrEmpty(mangledName))
+            mangledName = $"$s10TestModule{typeName.Length}{typeName}VycfC";
+
+        var method = new MethodDecl
+        {
+            Name = "init",
+            MangledName = mangledName,
+            MethodType = MethodType.Instance,
+            IsConstructor = true,
+            IsFailable = isFailable,
+            CSSignature = new List<ArgumentDecl> { CreateReturnArg(moduleDecl) },
+            GenericParameters = new List<GenericArgumentDecl>(),
+            ParentDecl = parentDecl,
+            ModuleDecl = moduleDecl,
+            Throws = throws,
+            IsAsync = false,
+            Visibility = Visibility.Public
+        };
+        parentDecl.Methods.Add(method);
+
+        // Simulate what MethodHandler does: set mangled name to cdecl symbol
+        var cdeclSymbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+            "TestModule", typeName, method.MangledName);
+        method.UsesCdeclConstructorWrapper = true;
+        method.MangledName = cdeclSymbol;
+
+        var env = new MethodEnvironment(method, typeDb);
+        var ctx = new ModuleEmissionContext();
+        return (env, ctx);
+    }
+
+    #endregion
+}

--- a/src/Swift.Bindings/tests/UnitTests/EmitterTests/ModuleDatabaseEmitterTests.cs
+++ b/src/Swift.Bindings/tests/UnitTests/EmitterTests/ModuleDatabaseEmitterTests.cs
@@ -368,6 +368,75 @@ namespace BindingsGeneration.Tests
             finally { Directory.Delete(dir, true); }
         }
 
+        [Fact]
+        public async Task Emit_NonCopyableStruct_RoundTrips()
+        {
+            var dir = CreateTempDir();
+            try
+            {
+                var module = new ModuleTypeDatabase("MyLib", "/fake/MyLib.dylib");
+                var swiftName = SwiftTypeName.FromModuleQualifiedName("MyLib.UniqueHandle");
+                var record = new TypeRecord
+                {
+                    CSharpTypeName = CSharpTypeName.FromNamespaceAndName("MyLib", "UniqueHandle"),
+                    SwiftTypeName = swiftName,
+                    MetadataAccessor = "$s5MyLib12UniqueHandleVMa",
+                    Flags = TypeRecordFlags.Frozen | TypeRecordFlags.NonCopyable,
+                    Kind = TypeRecordKind.Struct
+                };
+                module.RegisterType(swiftName, record);
+
+                var path = ModuleDatabaseEmitter.Emit(module, dir, NullLogger.Instance);
+                Assert.NotNull(path);
+
+                var xml = File.ReadAllText(path!);
+                Assert.Contains("nonCopyable=\"true\"", xml);
+
+                // Round-trip: load and verify NonCopyable flag survives
+                var typeDatabase = new TypeDatabase();
+                await typeDatabase.LoadModuleDatabaseFromFile(path);
+
+                Assert.True(typeDatabase.TryGetTypeRecord(swiftName, out var loaded));
+                Assert.Equal(TypeRecordKind.Struct, loaded!.Kind);
+                Assert.True(loaded.Flags.HasFlag(TypeRecordFlags.NonCopyable));
+                Assert.True(loaded.Flags.HasFlag(TypeRecordFlags.Frozen));
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public async Task Emit_CopyableStruct_DoesNotSetNonCopyableFlag()
+        {
+            var dir = CreateTempDir();
+            try
+            {
+                var module = new ModuleTypeDatabase("MyLib", "/fake/MyLib.dylib");
+                var swiftName = SwiftTypeName.FromModuleQualifiedName("MyLib.Point");
+                var record = new TypeRecord
+                {
+                    CSharpTypeName = CSharpTypeName.FromNamespaceAndName("MyLib", "Point"),
+                    SwiftTypeName = swiftName,
+                    MetadataAccessor = "$s5MyLib5PointVMa",
+                    Flags = TypeRecordFlags.Frozen,
+                    Kind = TypeRecordKind.Struct
+                };
+                module.RegisterType(swiftName, record);
+
+                var path = ModuleDatabaseEmitter.Emit(module, dir, NullLogger.Instance);
+                Assert.NotNull(path);
+
+                var xml = File.ReadAllText(path!);
+                Assert.DoesNotContain("nonCopyable", xml);
+
+                var typeDatabase = new TypeDatabase();
+                await typeDatabase.LoadModuleDatabaseFromFile(path);
+
+                Assert.True(typeDatabase.TryGetTypeRecord(swiftName, out var loaded));
+                Assert.False(loaded!.Flags.HasFlag(TypeRecordFlags.NonCopyable));
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
         private static string CreateTempDir()
         {
             var dir = Path.Combine(Path.GetTempPath(), $"mdb_emit_{Guid.NewGuid():N}");

--- a/src/docs/Completed/constructor-cdecl-wrappers-plan.md
+++ b/src/docs/Completed/constructor-cdecl-wrappers-plan.md
@@ -1,0 +1,888 @@
+# Constructor `@_cdecl` Wrappers — Implementation Plan
+
+**Created**: March 9, 2026
+**Status**: Ready (v5 — incorporates Codex review rounds 1+2+3+4)
+**Blocks**: Issues #10 (LottieAnimationView SIGSEGV), #12 (LottieColor SIGSEGV)
+**Depends on**: Destroy wrapper infrastructure (completed)
+
+---
+
+## Problem
+
+Constructor P/Invokes use `CallConvSwift`, which is broken on NativeAOT/ARM64 for:
+
+- **Struct parameters** (CGRect etc.) — register splitting mismatch → SIGSEGV
+- **Non-frozen struct indirect results** — NativeAOT mishandles `SwiftIndirectResult` → SIGSEGV
+
+This blocks all constructors that take structs or return non-frozen structs on device. The `__swift_memcpy24_8` crash (24-byte memcpy for 32-byte struct) confirms ABI mismatch between NativeAOT's CallConvSwift implementation and actual Swift ABI on ARM64.
+
+## Solution
+
+Route ALL constructor P/Invokes through `@_cdecl` Swift wrappers using **C calling convention** (`CallingConvention.Cdecl`), eliminating `CallConvSwift` for constructors entirely. Only in xcframework mode (where the wrapper library exists).
+
+**Core principle**: Preserve existing constructor wrapper/body semantics — only swap the native ABI boundary to cdecl. The existing projection/marshal-plan pipeline stays intact on the C# side. The `@_cdecl` wrapper on the Swift side absorbs all ABI translation.
+
+### Why `@_cdecl` and not `@_silgen_name`
+
+- `@_silgen_name` preserves Swift calling convention — same ABI, same crash
+- `@_cdecl` uses C calling convention — NativeAOT handles C ABI correctly
+- Destroy wrappers already use `@_cdecl` and are validated on device
+
+---
+
+## Design
+
+### Key Design Principle: ABI Boundary Swap, Not Marshalling Rewrite
+
+The `@_cdecl` wrapper sits between the C# P/Invoke and the actual Swift init. Its job is to translate the C calling convention into whatever the Swift init expects. The C# side continues to use the existing projection/marshal-plan infrastructure — it just talks to a different ABI at the boundary.
+
+This means:
+- **C# constructor body** (`WrapperEmitter.EmitConstructor`) keeps existing marshalling logic
+- **P/Invoke signature** changes calling convention and parameter types to C-compatible
+- **Swift `@_cdecl` wrapper** receives C-compatible params, reconstructs Swift types, calls init
+- **Existing marshal-plan outputs** (projection conversions, PayloadBuffer, bound generic buffers) remain as-is on the C# side — only the final P/Invoke parameter types change
+
+### Swift Side
+
+For each constructor, emit a `@_cdecl` function in the wrapper library:
+
+```swift
+// Class constructor (returns retained pointer)
+@_cdecl("SBW_Lottie_LottieAnimationView_init_8B933573")
+public func _sbw_init_8B933573(_ frame: UnsafeRawPointer) -> UnsafeMutableRawPointer {
+    let result = Lottie.LottieAnimationView(frame: frame.load(as: CGRect.self))
+    return Unmanaged.passRetained(result).toOpaque()
+}
+
+// Non-frozen struct constructor (writes to result buffer)
+@_cdecl("SBW_Lottie_LottieColor_init_A1B2C3D4")
+public func _sbw_init_A1B2C3D4(
+    _ resultPtr: UnsafeMutableRawPointer,
+    _ r: Double, _ g: Double, _ b: Double, _ a: Double, _ denominator: Double
+) {
+    let result = Lottie.LottieColor(r: r, g: g, b: b, a: a, denominator: denominator)
+    resultPtr.initializeMemory(as: Lottie.LottieColor.self, repeating: result, count: 1)
+}
+
+// Failable class constructor (returns nullable pointer)
+@_cdecl("SBW_Module_MyClass_init_HASH")
+public func _sbw_init_HASH(_ param: Int) -> UnsafeMutableRawPointer? {
+    guard let result = Module.MyClass(param: param) else { return nil }
+    return Unmanaged.passRetained(result).toOpaque()
+}
+
+// Failable non-frozen struct constructor (writes Optional<Self> to result buffer)
+@_cdecl("SBW_Module_MyStruct_init_HASH")
+public func _sbw_init_HASH(
+    _ resultPtr: UnsafeMutableRawPointer,
+    _ param: Int
+) {
+    let result: Module.MyStruct? = Module.MyStruct(param: param)
+    resultPtr.initializeMemory(as: Optional<Module.MyStruct>.self, repeating: result, count: 1)
+}
+
+// Throwing class constructor (error out-pointer)
+@_cdecl("SBW_Module_MyClass_init_throws_HASH")
+public func _sbw_init_throws_HASH(
+    _ errorOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
+    _ param: Int
+) -> UnsafeMutableRawPointer? {
+    do {
+        let result = try Module.MyClass(param: param)
+        return Unmanaged.passRetained(result).toOpaque()
+    } catch {
+        errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()
+        return nil
+    }
+}
+
+// Throwing struct constructor (error out-pointer + result buffer)
+@_cdecl("SBW_Module_MyStruct_init_throws_HASH")
+public func _sbw_init_throws_HASH(
+    _ resultPtr: UnsafeMutableRawPointer,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
+    _ param: Int
+) {
+    do {
+        let result = try Module.MyStruct(param: param)
+        resultPtr.initializeMemory(as: Module.MyStruct.self, repeating: result, count: 1)
+    } catch {
+        errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()
+    }
+}
+
+// Failable + throwing class constructor (error out-pointer, null = failed-or-nil)
+@_cdecl("SBW_Module_MyClass_init_failable_throws_HASH")
+public func _sbw_init_failable_throws_HASH(
+    _ errorOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
+    _ param: Int
+) -> UnsafeMutableRawPointer? {
+    do {
+        guard let result = try Module.MyClass(param: param) else { return nil }
+        return Unmanaged.passRetained(result).toOpaque()
+    } catch {
+        errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()
+        return nil
+    }
+}
+```
+
+### C# Side
+
+The existing P/Invoke emission infrastructure (`PInvokeEmitHelper`, `PInvokeEmissionInfo`, `PInvokeHelperContext`) already supports `PInvokeCallingConvention.Cdecl`. Use it — no new DllImport path needed.
+
+```csharp
+// Before (crashes on NativeAOT):
+[UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
+[LibraryImport("Lottie", EntryPoint = "$s6Lottie0A13AnimationViewC5frameACSo6CGRectV_tcfC")]
+private static partial IntPtr PInvoke_init(Swift.CGRect frame);
+
+// After (safe @_cdecl, using existing PInvokeEmitHelper with CallingConvention = Cdecl):
+[UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+[LibraryImport("LottieSwiftBindings", EntryPoint = "SBW_Lottie_LottieAnimationView_init_8B933573")]
+private static partial IntPtr PInvoke_init(IntPtr frame);
+```
+
+---
+
+## Parameter Marshalling: Reuse Existing Projections
+
+**Critical insight from Codex review**: Constructor arguments already flow through projection/marshal-plan logic. Some "struct-like" inputs (frozen structs projected as classes) require PayloadBuffer handling, not raw pointer loads. The wrapper must **reuse existing projection/marshal-plan outputs** and only lower the final ABI to cdecl.
+
+### How It Works
+
+1. **C# side** — existing marshalling pipeline runs as-is:
+   - `EmitTypeConversions()` → projection factory produces marshal-plan statements
+   - `EmitBoundGenericArguments()` → PayloadBuffer extraction for frozen-struct-as-class
+   - `EmitSafeHandleAddRef()` → SafeHandle reference counting
+   - The marshalled values (already `IntPtr`, `PayloadBuffer`, etc.) feed into the P/Invoke call
+
+2. **P/Invoke signature** — the `PInvokeSignatureBuilder` computes cdecl-compatible parameter types:
+   - Primitives → pass directly (same as today)
+   - Struct/class/enum params → `IntPtr` (pointer to data)
+   - Bool → `[MarshalAs(UnmanagedType.U1)] byte`
+   - Result buffer → `IntPtr` (for struct constructors, replaces `SwiftIndirectResult`)
+   - Error out → `IntPtr` (for throwing constructors, replaces `SwiftError`)
+
+3. **Swift `@_cdecl` wrapper** — receives C-compatible params, reconstructs Swift types:
+   - Primitives → no conversion needed
+   - Structs → `UnsafeRawPointer` → `.load(as: T.self)`
+   - Classes → `UnsafeMutableRawPointer` → `Unmanaged<T>.fromOpaque(_).takeUnretainedValue()`
+   - ObjC-bridged → `UnsafeMutableRawPointer` (passed as object pointer from .Handle)
+
+### Swift-Side Parameter Type Mapping
+
+| C# Marshal Output | Swift `@_cdecl` Param | Reconstruction |
+|---|---|---|
+| Primitives (int, double, etc.) | Same type directly | None |
+| Bool (byte via MarshalAs) | `Int8` | `param != 0` |
+| Frozen struct (PayloadBuffer → IntPtr) | `UnsafeRawPointer` | `.load(as: T.self)` |
+| Non-frozen struct (SafeHandle → IntPtr) | `UnsafeMutableRawPointer` | `.load(as: T.self)` |
+| Class (SafeHandle → IntPtr) | `UnsafeMutableRawPointer` | `Unmanaged<T>.fromOpaque(_).takeUnretainedValue()` |
+| ObjC-bridged (.Handle → IntPtr) | `UnsafeMutableRawPointer` | Bridged via ObjC runtime |
+| Simple enum (raw value) | Raw value type | Cast |
+| Complex enum (IntPtr to data) | `UnsafeRawPointer` | `.load(as: T.self)` |
+| Closures | Gate out initially | — |
+
+### Return Type Handling
+
+| Constructor Type | Swift Wrapper Return | C# P/Invoke Return |
+|---|---|---|
+| Class (Swift-rooted) | `UnsafeMutableRawPointer` (retained) | `IntPtr` → `SwiftSafeHandle<T>` |
+| Class (ObjC-rooted) | `UnsafeMutableRawPointer` (retained) | `IntPtr` → `NativeHandle` |
+| Struct (any) | void, writes to `resultPtr` param | Pass `IntPtr` buffer, read after call |
+
+---
+
+## Struct Result Buffer: `IntPtr`, NOT `SwiftIndirectResult`
+
+**Codex P1 finding (v3)**: The `@_cdecl` wrapper takes a plain C ABI `resultPtr` parameter, NOT a Swift ABI indirect-result register. `SwiftIndirectResult` is a Swift calling convention concept — it tells the NativeAOT runtime to pass a buffer pointer through a specific Swift register. Under `@_cdecl`, the buffer is just a regular `IntPtr` parameter.
+
+### What Changes
+
+**`PInvokeSignatureBuilder.HandleReturnType()`** (line 129-133):
+Currently injects `SwiftIndirectResult swiftIndirectResult` for non-frozen struct constructors. When `UsesCdeclConstructorWrapper` is set, inject a plain `IntPtr resultPtr` parameter instead:
+
+```csharp
+// Current (Swift ABI):
+if (MarshallingHelpers.MethodRequiresIndirectResult(_env))
+{
+    AddParameter("SwiftIndirectResult", "swiftIndirectResult");
+    SetReturnType("void");
+    return;
+}
+
+// With cdecl wrapper:
+if (methodDecl.UsesCdeclConstructorWrapper && MarshallingHelpers.MethodRequiresIndirectResult(_env))
+{
+    AddParameter("IntPtr", "resultPtr");  // plain C pointer, not Swift register
+    SetReturnType("void");
+    return;
+}
+```
+
+**`MethodMarshalPlanBuilder.BuildIndirectResultSetup()`** (line 287-337):
+Currently builds `SyncMethodPlan.IndirectResultConstructor` with:
+```csharp
+AllocationCode = $"""
+    _payload = new SwiftSafeHandle<{safeHandleTypeName}>((IntPtr)NativeMemory.Alloc(_payloadSize));
+    var swiftIndirectResult = new SwiftIndirectResult((void*)_payload.DangerousGetHandle());
+    """
+```
+
+When `UsesCdeclConstructorWrapper`, produce code that allocates the buffer BUT does NOT create `SwiftIndirectResult`:
+```csharp
+AllocationCode = $"""
+    _payload = new SwiftSafeHandle<{safeHandleTypeName}>((IntPtr)NativeMemory.Alloc(_payloadSize));
+    var resultPtr = _payload.DangerousGetHandle();
+    """
+```
+
+**`MethodMarshalPlanBuilder.BuildPInvokeCallStatement()`** (line 451):
+The `CallArgumentsString()` from `PInvokeSignatureBuilder` already produces the argument list. The variable name changes from `swiftIndirectResult` to `resultPtr`, which is enough — the call argument mapping uses the same variable name.
+
+**`WrapperEmitter.EmitIndirectResultConstructor()`** (line 355):
+Reads from `_syncPlan.IndirectResultConstructor.AllocationCode`. The plan builder produces the correct code based on the flag — no change needed in `WrapperEmitter` itself.
+
+### What Does NOT Change
+
+- `_payload` allocation (`NativeMemory.Alloc`) — same
+- `_payloadSize` computation — same
+- Post-call `_payload.DangerousGetHandle()` reads — same
+- `EmitReturnConstructor()` — same (struct path doesn't read a return value)
+- `EmitFailableFactory()` struct path — same VWT tag inspection on the result buffer
+
+The only concrete change is: `SwiftIndirectResult(buffer)` → plain `IntPtr buffer` in the P/Invoke parameter list and the allocation code.
+
+---
+
+## Failable Constructors (`init?`) — Explicit Contract
+
+**Codex P1 finding (v2)**: The original plan's blanket `IntPtr.Zero == nil` rule only works for pointer-returning class cases. Value-type `Optional<Self>` requires the existing VWT enum tag inspection.
+
+### Failable Class Constructors
+
+For classes, `init?` returns a nullable pointer. The `@_cdecl` wrapper handles this naturally:
+
+```swift
+// Swift @_cdecl wrapper
+@_cdecl("SBW_Module_MyClass_init_HASH")
+public func _sbw_init_HASH(_ param: Int) -> UnsafeMutableRawPointer? {
+    guard let result = Module.MyClass(param: param) else { return nil }
+    return Unmanaged.passRetained(result).toOpaque()
+}
+```
+
+C# side: The failable factory (`WrapperEmitter.EmitFailableFactory`) checks for `IntPtr.Zero` instead of VWT enum tag:
+
+```csharp
+// Simplified: no SwiftOptional metadata, no VWT tag inspection
+var resultPtr = PInvoke_init(params);
+if (resultPtr == IntPtr.Zero) { result = default; return false; }
+result = new TypeName((SwiftHandle)resultPtr);
+return true;
+```
+
+### Failable Value-Type Constructors (Structs/Enums)
+
+For value types, `init?` returns `Optional<Self>` — the wrapper writes the full Optional into the result buffer, **preserving the existing enum-tag contract**:
+
+```swift
+// Swift @_cdecl wrapper — writes Optional<Self> into result buffer
+@_cdecl("SBW_Module_MyStruct_init_HASH")
+public func _sbw_init_HASH(
+    _ resultPtr: UnsafeMutableRawPointer,
+    _ param: Int
+) {
+    let result: Module.MyStruct? = Module.MyStruct(param: param)
+    resultPtr.initializeMemory(as: Optional<Module.MyStruct>.self, repeating: result, count: 1)
+}
+```
+
+C# side: The failable factory (`WrapperEmitter.EmitFailableFactory`) **keeps the existing VWT-based tag inspection**. The only change is:
+- P/Invoke uses `IntPtr resultPtr` instead of `SwiftIndirectResult swiftIndirectResult`
+- The allocation code creates the buffer without wrapping in `SwiftIndirectResult`
+- All post-call inspection (`GetEnumTag`, `InitializeWithCopy`, payload extraction) stays identical
+
+### Failable Constructor Decision Matrix
+
+| Parent Type | `@_cdecl` Return | C# Factory Contract | VWT Tag Check? |
+|---|---|---|---|
+| Class (Swift-rooted) | `UnsafeMutableRawPointer?` | `IntPtr.Zero` == nil | No |
+| Class (ObjC-rooted) | `UnsafeMutableRawPointer?` | `IntPtr.Zero` == nil | No |
+| Struct (frozen value) | void + writes `Optional<Self>` to buffer | Existing FailableFactory path | Yes — `GetEnumTag` |
+| Struct (non-frozen / frozen+MM) | void + writes `Optional<Self>` to buffer | Existing FailableFactory path | Yes — `GetEnumTag` + `InitializeWithCopy` |
+
+---
+
+## Throwing Constructors (`init() throws`) — Explicit Contract
+
+**Codex P2 finding (v3)**: The current pipeline always carries `SwiftError` for throwing constructors. `SwiftError` is a Swift calling convention concept — the error is returned through a dedicated Swift register. Under `@_cdecl` (C ABI), that register doesn't exist. The plan must define how thrown Swift errors are reported through the C ABI boundary.
+
+### Error Reporting via Out-Pointer
+
+The `@_cdecl` wrapper catches Swift errors via `do/catch` and returns the error as a retained `AnyObject` pointer through an explicit out-parameter. This maps cleanly to an `IntPtr*` on the C# side.
+
+**Swift side** — `@_cdecl` wrapper catches and boxes the error:
+
+```swift
+// Throwing class constructor
+@_cdecl("SBW_Module_MyClass_init_throws_HASH")
+public func _sbw_init_throws_HASH(
+    _ errorOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
+    _ param: Int
+) -> UnsafeMutableRawPointer? {
+    do {
+        let result = try Module.MyClass(param: param)
+        return Unmanaged.passRetained(result).toOpaque()
+    } catch {
+        errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()
+        return nil  // signals failure; C# checks errorOut, not return value
+    }
+}
+
+// Throwing struct constructor
+@_cdecl("SBW_Module_MyStruct_init_throws_HASH")
+public func _sbw_init_throws_HASH(
+    _ resultPtr: UnsafeMutableRawPointer,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
+    _ param: Int
+) {
+    do {
+        let result = try Module.MyStruct(param: param)
+        resultPtr.initializeMemory(as: Module.MyStruct.self, repeating: result, count: 1)
+    } catch {
+        errorOut.pointee = Unmanaged.passRetained(error as AnyObject).toOpaque()
+    }
+}
+```
+
+**C# side** — replaces `SwiftError swiftError` with `IntPtr* errorOut`:
+
+```csharp
+// P/Invoke signature (cdecl wrapper mode):
+[UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+[LibraryImport("ModuleSwiftBindings", EntryPoint = "SBW_Module_MyClass_init_throws_HASH")]
+private static unsafe partial IntPtr PInvoke_init(IntPtr* errorOut, int param);
+
+// Constructor body:
+IntPtr errorPtr = IntPtr.Zero;
+var resultPtr = PInvoke_init(&errorPtr, param);
+if (errorPtr != IntPtr.Zero)
+{
+    // Existing error handling infrastructure — SBW_GetErrorDescription, SBW_ReleaseError,
+    // SBW_ExtractTypedError — all use @_cdecl and are already in the wrapper library.
+    // The error pointer is the same retained AnyObject as SwiftError.Value.
+    string _errorMessage;
+    var _descPtr = SBW_GetErrorDescription(errorPtr);
+    try { _errorMessage = Marshal.PtrToStringUTF8(_descPtr) ?? "Unknown Swift error"; }
+    finally { if (_descPtr != IntPtr.Zero) SBW_Free(_descPtr); SBW_ReleaseError(errorPtr); }
+    throw new SwiftRuntimeException(_errorMessage);
+}
+```
+
+### Why This Works Seamlessly
+
+The retained error pointer from `Unmanaged.passRetained(error as AnyObject).toOpaque()` is **identical** to what `SwiftError.Value` contains today. The existing error infrastructure (`SBW_GetErrorDescription`, `SBW_ReleaseError`, `SBW_ExtractTypedError_*`) all accept this same opaque pointer and are themselves `@_cdecl` functions. No changes needed to the error description/extraction infrastructure.
+
+### Changes Required
+
+**`PInvokeSignatureBuilder.HandleSwiftError()`** (line 567):
+Currently adds `SwiftError swiftError` with `out` modifier. When `UsesCdeclConstructorWrapper`:
+```csharp
+// Current:
+AddParameter("SwiftError", "swiftError", "out");
+
+// With cdecl wrapper:
+AddParameter("IntPtr", "errorOut", modifier: null, isUnsafePointer: true);
+// Emits: IntPtr* errorOut  (unsafe pointer parameter)
+```
+
+**`MethodMarshalPlanBuilder.BuildSwiftErrorSetup()`** (line 347):
+The `ErrorCheckCode` currently references `swiftError.Value`. When `UsesCdeclConstructorWrapper`, the check code references `errorPtr` instead:
+```csharp
+// Current:
+"if (swiftError.Value != null) { ... SBW_GetErrorDescription((IntPtr)swiftError.Value) ... }"
+
+// With cdecl wrapper:
+"if (errorPtr != IntPtr.Zero) { ... SBW_GetErrorDescription(errorPtr) ... }"
+```
+The error description/release/extraction calls stay identical — only the variable name and null check change.
+
+**`WrapperEmitter.EmitSwiftError()`** (line 397):
+Reads from `_syncPlan.SwiftError.ErrorCheckCode`. The plan builder produces the correct code based on the flag — no change needed in `WrapperEmitter`.
+
+### Throwing Constructor Decision Matrix
+
+| Constructor Type | `@_cdecl` Error Mechanism | C# Error Check | Reuses Existing Infra? |
+|---|---|---|---|
+| `init() throws` (class) | `errorOut` pointer + nil return | `errorPtr != IntPtr.Zero` | Yes — `SBW_GetErrorDescription` etc. |
+| `init() throws` (struct) | `errorOut` pointer | `errorPtr != IntPtr.Zero` | Yes — same |
+| `init?() throws` (class) | `errorOut` pointer + nil return | Check error first, then nil-check return | Yes |
+| `init?() throws` (struct) | `errorOut` pointer + `Optional<Self>` in buffer | Check error first, then VWT tag check | Yes |
+| Typed `init() throws(E)` | Same `errorOut` pointer | `SBW_ExtractTypedError_*` on errorPtr | Yes — same opaque pointer |
+
+---
+
+## P/Invoke Emission: Use Existing Infrastructure
+
+**Codex P2 finding (v2)**: Don't create a separate DllImport path. The existing `PInvokeEmitHelper` / `PInvokeEmissionInfo` already supports `PInvokeCallingConvention.Cdecl`, and `PInvokeHelperContext` / `PInvokeDeclaration` already has `OmitCallingConvention` (which maps to Cdecl). Reuse this.
+
+### For Non-Generic Types
+
+`PInvokeEmitter.EmitPInvoke()` already builds a `PInvokeEmissionInfo` and calls `PInvokeEmitHelper.EmitDeclaration()`. When `UsesCdeclConstructorWrapper` is set:
+- Set `CallingConvention = PInvokeCallingConvention.Cdecl`
+- Update entry point and library path to the wrapper symbol/library
+- The rest of the emission logic stays the same
+
+### For Generic Types
+
+`PInvokeEmitter.EmitPInvoke()` already routes generic types through `PInvokeHelperContext.AddDeclaration()` (line 678). The `PInvokeDeclaration` already has `OmitCallingConvention` which maps to Cdecl. Set this flag when `UsesCdeclConstructorWrapper` is true. No new code path needed.
+
+### Generic Type Gate: Swift Side Is the Real Blocker
+
+The generic constructor wrapper gate is on the **Swift side**, not just C# CS7042. `DefaultParameterOverloadEmitter` already skips generic parent types (line 49-53) because Swift extension syntax can't express generic parameters (`extension Keyframe` instead of `extension Keyframe<T>`), and generic type params (`τ_0_0`) aren't valid Swift identifiers. The same constraint applies to `@_cdecl` constructor wrappers.
+
+For generic types: fall back to current `CallConvSwift` P/Invoke. This is acceptable because:
+- Most consumer-facing constructors are on non-generic types
+- The pattern matches destroy wrappers (which also skip generics)
+- Generic constructor crashes on device would need a different solution (e.g., TypeMetadata-based dispatch)
+
+---
+
+## Implementation Steps
+
+### Step 1: `ConstructorWrapperEmitter.cs` (new file)
+
+New emitter following the `DestroyWrapperEmitter` pattern.
+
+**Key methods:**
+- `ShouldEmitWrapper(env)` — **pure query, no side effects.** Guards: xcframework mode, non-generic parent type, has wrapper lib. Called BEFORE `SignatureHandler` construction to set `MethodDecl` flags early enough.
+- `EmitSwiftConstructorWrapper(swiftWriter, env, ctx)` — renders `@_cdecl` Swift function per constructor. Handles:
+  - Parameter type conversion (primitives pass through, structs/classes as `UnsafeRawPointer`/`UnsafeMutableRawPointer`)
+  - Return type: class → `UnsafeMutableRawPointer`, struct → void + `resultPtr` param
+  - Failable: class → `UnsafeMutableRawPointer?`, struct → writes `Optional<Self>` to `resultPtr`
+  - Throwing: `do/catch` block, error written to `errorOut` pointer parameter
+  - Failable + throwing: combined pattern (error out-pointer + nil return or Optional buffer)
+  - Default parameter overloads: wrapper calls the existing `@_silgen_name` function (no double-wrapping of Swift init logic)
+- `GetConstructorSymbolName(moduleName, typeName, hash)` — naming: `SBW_{Module}_{Type}_init_{Hash}`
+- Dedup via `ModuleEmissionContext.TryAddConstructorWrapperSymbol()`
+
+**Does NOT emit C# P/Invoke** — that stays in `PInvokeEmitter.EmitPInvoke()` using existing infrastructure.
+
+**Naming convention:** `SBW_{Module}_{Type}_init_{Hash}` where hash is the existing P/Invoke hash from `NameProvider`.
+
+### Step 2: MethodHandler Integration — ALL Mutations BEFORE SignatureHandler
+
+**Codex P1 findings (v4, v5)**: `SignatureHandler` construction triggers `PInvokeSignatureBuilder` (which reads `UsesCdeclConstructorWrapper` to decide `SwiftIndirectResult` vs `IntPtr`) AND `MethodMarshalPlanBuilder.BuildPInvokeCallStatement()` (which calls `NameProvider.GetPInvokeName()`, hashing `MangledName` to produce the P/Invoke method name). If either `UsesCdeclConstructorWrapper` or `MangledName` is set after `SignatureHandler` construction, the P/Invoke shape and/or the call-site name will be wrong.
+
+**All three mutations must happen BEFORE `new SignatureHandler()`:**
+1. `UsesCdeclConstructorWrapper = true` — so PInvokeSignatureBuilder emits `IntPtr`/`IntPtr*`
+2. `UsesWrapperLibrary = true` — so PInvokeEmitter routes to wrapper library
+3. `MangledName = cdeclSymbol` — so `GetPInvokeName()` hashes the correct symbol
+
+The `@_cdecl` symbol name is a pure function of (moduleName, typeName, originalHash) — it can be computed without side effects, before any emission.
+
+**Required ordering in `MethodHandler.cs`:**
+
+```csharp
+// BEFORE SignatureHandler creation (before line 319):
+// Set ALL cdecl-related state so SignatureHandler sees the final method shape.
+// GetConstructorSymbolName is a pure function — no Swift emission yet.
+if (ConstructorWrapperEmitter.ShouldEmitWrapper(methodEnv))
+{
+    var cdeclSymbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+        moduleName, typeName, methodEnv.MethodDecl.MangledName);
+    methodEnv.MethodDecl.UsesCdeclConstructorWrapper = true;
+    methodEnv.MethodDecl.UsesWrapperLibrary = true;
+    methodEnv.MethodDecl.MangledName = cdeclSymbol;
+    // Swift @_cdecl function emitted later (after signature validation)
+}
+
+// Existing: emit debug param wrapper (line 312-317)
+// ...
+
+var signatureHandler = new SignatureHandler(methodEnv);  // line 319
+// SignatureHandler now sees:
+//   - UsesCdeclConstructorWrapper → IntPtr resultPtr, IntPtr* errorOut
+//   - MangledName = cdeclSymbol → GetPInvokeName() hashes the correct symbol
+//   - UsesWrapperLibrary → routes to wrapper library path
+
+if (signatureHandler.GetWrapperSignature().ContainsPlaceholder)  // line 321
+{
+    // ... skip unsupported signatures (existing)
+    return;
+}
+
+// Existing: closure/optional wrapper checks (lines 333-356)
+// ...
+
+// AFTER signature validation: emit the Swift @_cdecl wrapper.
+// The symbol name was already computed above — this just generates the Swift code.
+if (methodEnv.MethodDecl.UsesCdeclConstructorWrapper)
+{
+    ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(swiftWriter, methodEnv, ctx);
+}
+
+// Existing: CheckExportedSymbol, WrapperEmitter, EmitPInvoke (lines 358-384)
+// WrapperEmitter reads _syncPlan.PInvokeCallStatement which uses GetPInvokeName()
+//   → hashes MangledName (already set to cdeclSymbol) → correct name ✓
+// PInvokeEmitter reads MangledName via ComputeEntryPoint()
+//   → emits declaration with same hashed name → matches call site ✓
+```
+
+This is stricter than the existing closure/optional flag pattern (lines 333-356), which can afford to set flags between `SignatureHandler` and `WrapperEmitter` because those flags only affect library path and closure shapes — not the P/Invoke method name or parameter types.
+
+### Step 3: DefaultParameterOverloadEmitter Integration — Same Mutations-First Pattern
+
+**Codex P1 finding (v3)**: `DefaultParameterOverloadEmitter` emits constructor overloads and their P/Invokes **directly** (lines 128-141), bypassing the MethodHandler constructor branch. Without an explicit hook, DBW constructor overloads will keep emitting `CallConvSwift` P/Invokes to the `@_silgen_name` wrappers.
+
+**Codex P1 findings (v4, v5)**: Same timing issue as MethodHandler — all three mutations (`UsesCdeclConstructorWrapper`, `UsesWrapperLibrary`, `MangledName`) must happen before `SignatureHandler` construction at line 88.
+
+**Sequencing note for `MangledName`**: In this path, `EmitSwiftWrapper()` (line 115) sets `overloadDecl.MangledName` to the `@_silgen_name` symbol. Our `@_cdecl` wrapper wraps that `@_silgen_name` function, so the `@_cdecl` symbol is computed from the overload's original mangled name (before `EmitSwiftWrapper` changes it). We must compute and set the final `MangledName` (the `@_cdecl` symbol) BEFORE `SignatureHandler`, saving the intermediate `@_silgen_name` symbol for the Swift wrapper to reference internally.
+
+**Required changes in `DefaultParameterOverloadEmitter.EmitOverload()`:**
+
+```csharp
+// Create environment with overload decl (existing, line 80-85)
+var overloadEnv = new MethodEnvironment(overloadDecl, ...);
+
+// NEW: Set ALL cdecl state BEFORE SignatureHandler construction.
+// Compute the @_cdecl symbol from the original MangledName (before EmitSwiftWrapper changes it).
+string? silgenSymbol = null;
+if (overloadDecl.IsConstructor && ConstructorWrapperEmitter.ShouldEmitWrapper(overloadEnv))
+{
+    var cdeclSymbol = ConstructorWrapperEmitter.GetConstructorSymbolName(
+        moduleName, typeName, overloadDecl.MangledName);
+    overloadDecl.UsesCdeclConstructorWrapper = true;
+    overloadDecl.UsesWrapperLibrary = true;
+    // Save original MangledName so EmitSwiftWrapper can compute @_silgen_name from it
+    var originalMangledName = overloadDecl.MangledName;
+    overloadDecl.MangledName = cdeclSymbol;
+    // EmitSwiftWrapper will need the @_silgen_name symbol — computed separately
+    silgenSymbol = /* computed from originalMangledName by EmitSwiftWrapper */;
+}
+
+// Existing (line 88) — now sees UsesCdeclConstructorWrapper + final MangledName
+var signatureHandler = new SignatureHandler(overloadEnv);
+if (signatureHandler.GetWrapperSignature().ContainsPlaceholder) { ... continue; }
+
+// Existing: emit Swift @_silgen_name wrapper (line 115)
+// EmitSwiftWrapper uses the @_silgen_name symbol (not MangledName, which is now @_cdecl)
+EmitSwiftWrapper(swiftWriter, methodDecl, overloadDecl, env);
+
+// NEW: Emit @_cdecl wrapper that calls the @_silgen_name function
+if (overloadDecl.UsesCdeclConstructorWrapper)
+{
+    ConstructorWrapperEmitter.EmitSwiftConstructorWrapper(
+        swiftWriter, overloadEnv, emissionContext, silgenTarget: silgenSymbol);
+}
+
+// Existing: WrapperEmitter + PInvokeEmitter (lines 128-141)
+// WrapperEmitter.BuildPInvokeCallStatement → GetPInvokeName() hashes MangledName (=cdeclSymbol)
+// PInvokeEmitter.EmitPInvoke → GetPInvokeName() hashes same MangledName → names match ✓
+var wrapperEmitter = new WrapperEmitter(overloadEnv, signatureHandler, fallbackInfo, emissionContext);
+if (overloadDecl.IsConstructor && !overloadDecl.IsFailable && !overloadDecl.IsAsync)
+    wrapperEmitter.EmitConstructor(csWriter);
+else if (overloadDecl.IsConstructor && overloadDecl.IsFailable)
+    wrapperEmitter.EmitFailableFactory(csWriter);
+else
+    wrapperEmitter.EmitMethod(csWriter, swiftWriter);
+PInvokeEmitter.EmitPInvoke(csWriter, overloadEnv, signatureHandler);
+```
+
+**Implementation note**: `EmitSwiftWrapper()` currently reads and mutates `overloadDecl.MangledName` internally (line 704). This will need a minor refactor: either (a) `EmitSwiftWrapper` accepts the `@_silgen_name` symbol as a parameter instead of computing it from `MangledName`, or (b) `EmitSwiftWrapper` uses a stored original name. Option (a) is cleaner and avoids hidden state dependencies.
+
+The `@_cdecl` wrapper calls the `@_silgen_name` function, chaining cleanly:
+
+```
+C# → @_cdecl (C ABI) → @_silgen_name (Swift ABI, default params) → Swift init
+```
+
+This ensures ALL constructor P/Invokes — both primary and default-parameter overloads — use `CallingConvention.Cdecl`, and the P/Invoke signatures are computed with the correct cdecl parameter types.
+
+### Step 4: PInvokeEmitter / PInvokeSignatureBuilder Changes
+
+**PInvokeEmitter.EmitPInvoke()** (line 664):
+- When `UsesCdeclConstructorWrapper` is set, build `PInvokeEmissionInfo` with `CallingConvention = PInvokeCallingConvention.Cdecl`
+- For generic types, set `OmitCallingConvention = true` on `PInvokeDeclaration` (already maps to Cdecl)
+- Entry point and library path already handled by `ComputeEntryPoint()` + `UsesWrapperLibrary` flag
+
+**PInvokeSignatureBuilder.HandleReturnType()** (line 129):
+When `UsesCdeclConstructorWrapper` and `MethodRequiresIndirectResult`:
+- Inject `IntPtr resultPtr` parameter instead of `SwiftIndirectResult swiftIndirectResult`
+- Set return type to `void` (same as before)
+- For class constructors: return `IntPtr` directly (same as current behavior post-fix #1)
+
+**PInvokeSignatureBuilder.HandleSwiftError()** (line 567):
+When `UsesCdeclConstructorWrapper` and method throws:
+- Inject `IntPtr* errorOut` parameter instead of `SwiftError swiftError` with `out` modifier
+- This produces a raw pointer parameter that requires `unsafe` on the P/Invoke declaration
+
+**PInvokeEmitter unsafe detection** (line 711):
+**Codex P2 finding (v4)**: The current `IsUnsafe` check uses substring matching: `pInvokeParams.Contains("void*") || pInvokeParams.Contains("delegate*")`. The new `IntPtr* errorOut` parameter won't match either pattern, so the emitted P/Invoke will fail to compile (CS0227: unsafe code requires `/unsafe`).
+
+Fix: extend the check to include `IntPtr*`:
+```csharp
+// Current (line 711):
+IsUnsafe = pInvokeParams.Contains("void*") || pInvokeParams.Contains("delegate*")
+
+// Fixed:
+IsUnsafe = pInvokeParams.Contains("void*") || pInvokeParams.Contains("delegate*") || pInvokeParams.Contains("IntPtr*")
+```
+
+Alternatively, `PInvokeSignatureBuilder` could track `RequiresUnsafe` structurally (set when adding any pointer parameter) and expose it on the signature object, avoiding substring matching entirely. But the minimal fix above is sufficient for this feature and matches the existing pattern.
+
+### Step 5: MethodMarshalPlanBuilder Changes
+
+**`BuildIndirectResultSetup()`** (line 287):
+When `UsesCdeclConstructorWrapper`, produce allocation code that creates `IntPtr resultPtr` instead of `SwiftIndirectResult`:
+```csharp
+// Current:
+_payload = new SwiftSafeHandle<T>((IntPtr)NativeMemory.Alloc(_payloadSize));
+var swiftIndirectResult = new SwiftIndirectResult((void*)_payload.DangerousGetHandle());
+
+// With cdecl wrapper:
+_payload = new SwiftSafeHandle<T>((IntPtr)NativeMemory.Alloc(_payloadSize));
+var resultPtr = _payload.DangerousGetHandle();
+```
+
+**`BuildSwiftErrorSetup()`** (line 347):
+When `UsesCdeclConstructorWrapper`, produce error check code that references `errorPtr` (from the out-pointer) instead of `swiftError.Value`:
+```csharp
+// Current:
+if (swiftError.Value != null) { var _errorPtr = (IntPtr)swiftError.Value; ... }
+
+// With cdecl wrapper:
+if (errorPtr != IntPtr.Zero) { ... SBW_GetErrorDescription(errorPtr) ... }
+```
+All downstream error handling (`SBW_GetErrorDescription`, `SBW_ReleaseError`, `SBW_ExtractTypedError_*`) stays identical — the opaque error pointer is the same format.
+
+**`BuildPInvokeCallStatement()`** (line 451):
+The `CallArgumentsString()` from `PInvokeSignatureBuilder` uses the parameter names from `HandleReturnType`/`HandleSwiftError`. Since those now produce `resultPtr`/`errorOut` instead of `swiftIndirectResult`/`swiftError`, the call statement updates automatically.
+
+### Step 6: WrapperEmitter Changes (Minimal)
+
+The key insight is that **most constructor body logic stays the same**. The marshal-plan pipeline on the C# side already converts parameters to their P/Invoke-compatible forms. What changes:
+
+- `EmitConstructor()` — when using cdecl wrapper, struct parameters that were previously passed by value (e.g., `Swift.CGRect frame`) now need to be passed as `IntPtr` (pointer to the struct data). Add `fixed` or `Unsafe.AsPointer` conversion for these cases.
+- `EmitIndirectResultConstructor()` — reads from `_syncPlan.IndirectResultConstructor.AllocationCode` which the plan builder has already adapted (plain `IntPtr` instead of `SwiftIndirectResult`). No change needed here.
+- `EmitReturnConstructor()` — class return path: read `IntPtr` from P/Invoke return value (same as current post-fix #1 behavior). Struct return path: result buffer stays the same.
+- `EmitObjCRootedConstructor()` — same minimal changes for the static helper.
+- `EmitSwiftError()` — reads from `_syncPlan.SwiftError.ErrorCheckCode` which the plan builder has already adapted. No change needed here.
+- `EmitFailableFactory()` — two sub-paths:
+  - **Class failable**: simplified path (no VWT tag check, just `IntPtr.Zero` == nil)
+  - **Struct failable**: existing path preserved (VWT tag check, payload copy), but with `IntPtr resultPtr` instead of `SwiftIndirectResult`
+
+### Step 7: ModuleEmissionContext Tracking
+
+Add parallel to destroy wrapper tracking:
+
+```csharp
+private readonly HashSet<string> _constructorWrapperSymbols = new();
+
+public bool HasConstructorWrapperSymbol(string symbol) => _constructorWrapperSymbols.Contains(symbol);
+public bool TryAddConstructorWrapperSymbol(string symbol) => _constructorWrapperSymbols.Add(symbol);
+```
+
+### Step 8: Edge Cases
+
+**Generic parent types:** Skip — Swift can't express generic params in `@_cdecl` free functions (`τ_0_0` isn't a valid identifier). Same constraint as `DefaultParameterOverloadEmitter` (line 49-53). Fall back to current `CallConvSwift` P/Invoke.
+
+**Closures in constructor params:** Gate out initially. These already have the separate `ClosureCdeclWrapper` path for the closure itself, but combining with constructor wrapper adds complexity. Defer to follow-up.
+
+**Frozen structs projected as classes (PayloadBuffer):** The existing `EmitBoundGenericArguments()` and `EmitSafeHandleAddRef()` already produce `IntPtr` from `PayloadBuffer<T>`. These marshal-plan outputs feed directly into the cdecl P/Invoke — no additional conversion needed on the C# side. The Swift `@_cdecl` wrapper receives the `IntPtr` and reconstructs via `.load(as:)`.
+
+### Step 9: Tests
+
+- Unit tests for `ConstructorWrapperEmitter` (parallel to `DestroyWrapperEmitterTests`)
+- TestFramework cases: struct param constructors, non-frozen struct constructors, throwing constructors, failable+throwing constructors
+- Validation: Nuke (DataCache), Lottie (LottieAnimationView, LottieColor)
+- Golden file updates
+
+---
+
+## Risk Assessment
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Breaking existing working constructors | High | Gate behind xcframework mode only; fallback to current CallConvSwift when no wrapper lib |
+| Failable struct marshalling regression | High | Keep existing VWT tag/payload extraction; only change buffer parameter type |
+| Throwing constructor error loss | High | Error pointer is same format as `SwiftError.Value` — existing infra handles it |
+| DefaultParam overload bypass | High | Explicit hook in `DefaultParameterOverloadEmitter.EmitOverload()` with flag-before-SignatureHandler ordering |
+| `SwiftIndirectResult` artifact | High | Explicitly replaced with `IntPtr resultPtr` in PInvokeSignatureBuilder + plan builder |
+| SignatureHandler timing | High | ALL three mutations (`UsesCdeclConstructorWrapper`, `UsesWrapperLibrary`, `MangledName`) set BEFORE `SignatureHandler` construction in both paths — ensures P/Invoke shape AND call-site name are correct |
+| `IntPtr*` unsafe detection | Medium | Extend `PInvokeEmitter` IsUnsafe check to match `IntPtr*` (line 711) |
+| Parameter marshalling bugs | Medium | Reuse existing projection/marshal-plan outputs — only lower final ABI types |
+| Test regressions | Medium | Run full test suite + golden file check after each step |
+| Generic types | Low | Skip with clear gate; same constraint as destroy wrappers + DefaultParameterOverloadEmitter |
+
+---
+
+## What This Fixes
+
+- **Issue #10**: LottieAnimationView(CGRect) — struct params via C ABI instead of CallConvSwift
+- **Issue #12**: LottieColor(r:g:b:a:denominator:) — result buffer via C ABI instead of CallConvSwift
+- **All future constructor crashes** from CallConvSwift mismatches on NativeAOT
+
+## What This Does NOT Fix
+
+- **Issue #11**: LottieAnimationView() returning null — likely `@MainActor` isolation, not CallConvSwift
+- **Generic parent type constructors** — Swift can't express generic params in `@_cdecl` free functions
+- **Closure parameter constructors** — deferred to follow-up (separate complexity)
+
+---
+
+## Files Affected
+
+### New Files
+- `src/Swift.Bindings/src/Emitter/StringEmitter/ConstructorWrapperEmitter.cs`
+- `src/Swift.Bindings/tests/UnitTests/EmitterTests/ConstructorWrapperEmitterTests.cs`
+
+### Modified Files
+- `src/Swift.Bindings/src/Model/TypeDecl/MethodDecl.cs` — new `UsesCdeclConstructorWrapper` flag
+- `src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs` — integration point (emit Swift wrapper, set flags)
+- `src/Swift.Bindings/src/Emitter/StringEmitter/Handler/DefaultParameterOverloadEmitter.cs` — **explicit hook** for constructor overload wrappers (lines 128-141)
+- `src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PInvokeEmitter.cs` — set `CallingConvention.Cdecl` when flag is set
+- `src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PInvokeSignatureBuilder.cs` — `IntPtr resultPtr` instead of `SwiftIndirectResult`; `IntPtr* errorOut` instead of `SwiftError`
+- `src/Swift.Bindings/src/Marshaler/Projection/MethodMarshalPlanBuilder.cs` — `BuildIndirectResultSetup` and `BuildSwiftErrorSetup` cdecl paths
+- `src/Swift.Bindings/src/Emitter/StringEmitter/Handler/WrapperEmitter.cs` — minor: struct params as IntPtr
+- `src/Swift.Bindings/src/Emitter/StringEmitter/Handler/WrapperEmitter.Return.cs` — minor: class return from IntPtr
+- `src/Swift.Bindings/src/Emitter/StringEmitter/Handler/WrapperEmitter.FailableFactory.cs` — class-failable simplified path; struct-failable `IntPtr` buffer
+- `src/Swift.Bindings/src/Emitter/StringEmitter/ModuleEmissionContext.cs` — dedup tracking
+
+---
+
+## Architecture Reference
+
+### Destroy Wrapper Pattern (proven, model to follow)
+
+```
+DestroyWrapperEmitter.EmitIfNeeded()
+├── Guards: xcframework mode, non-generic type, has wrapper lib
+├── EmitSwiftDestroyWrapper() → @_cdecl("SBW_Destroy_{Module}_{Type}")
+├── EmitCSharpDestroyRegistration() → [DllImport] + RegisterDestroyAction()
+└── Dedup via ModuleEmissionContext.TryAddDestroyWrapperSymbol()
+```
+
+### Constructor Wrapper Pattern (proposed)
+
+```
+ConstructorWrapperEmitter.EmitIfNeeded()
+├── Guards: xcframework mode, non-generic parent, has wrapper lib, no closure params
+├── EmitSwiftConstructorWrapper() → @_cdecl("SBW_{Module}_{Type}_init_{Hash}")
+│   ├── Non-failable class → returns UnsafeMutableRawPointer (retained)
+│   ├── Non-failable struct → writes to resultPtr via initializeMemory
+│   ├── Failable class → returns UnsafeMutableRawPointer? (nil == failure)
+│   ├── Failable struct → writes Optional<Self> to resultPtr
+│   ├── Throwing → do/catch, error to errorOut pointer
+│   └── Failable+throwing → combined pattern
+├── Sets UsesCdeclConstructorWrapper + UsesWrapperLibrary + MangledName
+└── Dedup via ModuleEmissionContext.TryAddConstructorWrapperSymbol()
+```
+
+### Existing P/Invoke Infrastructure (reused, not duplicated)
+
+```
+PInvokeEmitter.EmitPInvoke()
+├── Non-generic → PInvokeEmitHelper.EmitDeclaration(PInvokeEmissionInfo)
+│   └── CallingConvention = Cdecl (when UsesCdeclConstructorWrapper)
+├── Generic → PInvokeHelperContext.AddDeclaration(PInvokeDeclaration)
+│   └── OmitCallingConvention = true (maps to Cdecl)
+└── Entry point + library path from ComputeEntryPoint() + UsesWrapperLibrary
+```
+
+### Current Constructor Flow (to be modified)
+
+```
+MethodHandler.Emit()
+  → ConstructorHandler guards
+  → DefaultParameterOverloadEmitter (if defaults)
+  │   → @_silgen_name wrapper
+  │   → WrapperEmitter.EmitConstructor()
+  │   → PInvokeEmitter.EmitPInvoke() → CallConvSwift  ← BYPASSES MethodHandler
+  → SignatureHandler(methodEnv)  ← P/Invoke shape locked here
+  → closure/optional wrapper flags (lines 333-356)
+  → WrapperEmitter.EmitConstructor() → constructor body
+    → EmitIndirectResultConstructor() → SwiftIndirectResult
+    → EmitTypeConversions() → projection/marshal-plan
+    → EmitBoundGenericArguments() → PayloadBuffer extraction
+    → P/Invoke call (CallConvSwift)
+    → EmitSwiftError() → swiftError.Value check
+    → EmitReturnConstructor() → SafeHandle wrapping
+  → PInvokeEmitter.EmitPInvoke() → CallConvSwift
+```
+
+### Proposed Constructor Flow
+
+```
+MethodHandler.Emit()
+  → ConstructorHandler guards
+  → DefaultParameterOverloadEmitter (if defaults)
+  │   → UsesCdeclConstructorWrapper + MangledName = cdeclSymbol  ← NEW (BEFORE SigHandler)
+  │   → SignatureHandler(overloadEnv)  ← sees cdecl flag + final MangledName
+  │   → @_silgen_name wrapper
+  │   → ConstructorWrapperEmitter.EmitSwiftWrapper() → @_cdecl  ← NEW
+  │   → WrapperEmitter.EmitConstructor()  ← GetPInvokeName hashes cdeclSymbol ✓
+  │   → PInvokeEmitter.EmitPInvoke() → CallingConvention.Cdecl  ← hashes same ✓
+  → UsesCdeclConstructorWrapper + MangledName = cdeclSymbol  ← NEW (BEFORE SigHandler)
+  → SignatureHandler(methodEnv)  ← sees cdecl flag + final MangledName
+  → closure/optional wrapper flags (lines 333-356)
+  → ConstructorWrapperEmitter.EmitSwiftWrapper() → @_cdecl  ← NEW
+  → WrapperEmitter.EmitConstructor() → constructor body
+    → EmitIndirectResultConstructor() → IntPtr resultPtr (NOT SwiftIndirectResult)  ← CHANGED
+    → EmitTypeConversions() → projection/marshal-plan (same)
+    → EmitBoundGenericArguments() → PayloadBuffer extraction (same)
+    → P/Invoke call (Cdecl, through @_cdecl wrapper)  ← name matches declaration ✓
+    → EmitSwiftError() → errorPtr != IntPtr.Zero check  ← CHANGED
+    → EmitReturnConstructor() → SafeHandle wrapping (same)
+  → PInvokeEmitter.EmitPInvoke() → CallingConvention.Cdecl  ← hashes same MangledName ✓
+```
+
+### Failable Constructor Flow
+
+```
+Non-failable:
+  C# ──[cdecl]──→ @_cdecl wrapper ──[swift]──→ Swift init
+                                                    │
+                                          (class) return retained ptr
+                                          (struct) write to resultPtr
+
+Failable class:
+  C# ──[cdecl]──→ @_cdecl wrapper ──[swift]──→ Swift init?
+                                                    │
+                                          guard let → retained ptr
+                                          nil → return null (IntPtr.Zero)
+
+Failable struct:
+  C# ──[cdecl]──→ @_cdecl wrapper ──[swift]──→ Swift init?
+                                                    │
+                                          write Optional<Self> to resultPtr
+                                          C# uses existing VWT tag check
+```
+
+### Throwing Constructor Flow
+
+```
+Throwing class:
+  C# ──[cdecl]──→ @_cdecl wrapper ──[swift]──→ try Swift init()
+                                                    │
+                                          success → return retained ptr
+                                          catch → write error to errorOut, return nil
+                                          C# checks errorPtr, reuses SBW_GetErrorDescription
+
+Throwing struct:
+  C# ──[cdecl]──→ @_cdecl wrapper ──[swift]──→ try Swift init()
+                                                    │
+                                          success → write to resultPtr
+                                          catch → write error to errorOut
+                                          C# checks errorPtr before reading resultPtr
+
+Failable + Throwing class:
+  C# ──[cdecl]──→ @_cdecl wrapper ──[swift]──→ try Swift init?()
+                                                    │
+                                          success → return retained ptr
+                                          nil → return null (no error)
+                                          catch → write error to errorOut, return nil
+                                          C# checks errorPtr FIRST, then nil-checks return
+```

--- a/src/docs/device-validation-fixes.md
+++ b/src/docs/device-validation-fixes.md
@@ -53,8 +53,13 @@
 ### 4. DllImport Resolver for Late-Loaded Assemblies (Issue 4)
 
 **Status**: No code change needed — resolved by rebuilding packages
+**Severity**: Medium
 
-Generated bindings already emit per-assembly `[ModuleInitializer]` + `SetDllImportResolver`. Rebuilding the packages with the current generator was sufficient.
+The original ISSUES.md reported `DllNotFoundException: NukeSwiftBindings` because the old NuGet packages were built before the generator emitted `[ModuleInitializer]` resolvers. Rebuilding the packages with the current generator fixed it.
+
+**How it works**: Every generated binding assembly includes `__SwiftFrameworkResolver_{Module}` with a `[ModuleInitializer]` that calls `NativeLibrary.SetDllImportResolver`. When .NET lazily loads the binding assembly on first type access, the initializer fires and registers a resolver that maps DllImport names to `@rpath/{name}.framework/{name}`. This is per-assembly, so it doesn't conflict with the consumer app's own resolvers. Zero consumer boilerplate required.
+
+**File**: `src/Swift.Bindings/src/Emitter/StringEmitter/Handler/ModuleHandler.cs:253` (`EmitFrameworkResolver`)
 
 ---
 
@@ -135,11 +140,11 @@ No code changes needed. Issue 8's destroy wrappers make Dispose() safe for all n
 
 ---
 
-## Open Issues — NativeAOT CallConvSwift Limitations
+## Recently Fixed — Constructor @_cdecl Wrappers
 
 ### 10. LottieAnimationView(CGRect) SIGSEGV (Issue 2b)
 
-**Status**: NativeAOT limitation — needs constructor @_cdecl wrappers
+**Status**: Done — unblocked by #14 fix, pending device revalidation
 **Severity**: High — blocks all LottieAnimationView construction
 
 The ObjC constructor return path fix (#2) resolved DataCache but NOT LottieAnimationView(CGRect). Round 4 confirmed the fix is deployed (code offset changed), but the crash persists.
@@ -152,13 +157,117 @@ private static partial IntPtr PInvoke_init_8B933573( Swift.CGRect frame);
 ```
 CGRect (32 bytes, 4 Doubles) is passed directly via CallConvSwift. On ARM64 NativeAOT, the struct parameter splitting across registers/memory differs from what Swift expects. The `__swift_memcpy24_8` crash (24-byte memcpy for 32-byte struct) confirms the ABI mismatch.
 
-**Fix approach**: Generate constructor `@_cdecl` wrappers in the Swift wrapper library, similar to destroy wrappers. The wrapper would take parameters via C calling convention and call the Swift init internally. This is a significant feature requiring:
-- New `ConstructorWrapperEmitter` (per-constructor wrapper generation)
-- Integration with `WrapperEmitter` to redirect P/Invoke calls through wrapper
-- Handling of ObjC-rooted vs non-ObjC, class vs struct return conventions
-- Default parameter overloads, failable inits, generic parameters
+**Fix**: `ConstructorWrapperEmitter` routes all constructor P/Invokes through `@_cdecl` Swift wrappers using `CallingConvention.Cdecl`. See `src/docs/Completed/constructor-cdecl-wrappers-plan.md`.
 
-**Scope**: Dedicated session — touches the core constructor emission pipeline.
+**Files**:
+- `src/Swift.Bindings/src/Emitter/StringEmitter/ConstructorWrapperEmitter.cs` (new)
+- `src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PInvokeEmitter.cs`
+- `src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs`
+- `src/Swift.Bindings/src/Emitter/StringEmitter/Handler/DefaultParameterOverloadEmitter.cs`
+- `src/Swift.Bindings/src/Marshaler/Projection/MethodMarshalPlanBuilder.cs`
+- `src/Swift.Bindings/tests/UnitTests/EmitterTests/ConstructorWrapperEmitterTests.cs` (new, 36 tests)
+
+**Pending**: Device revalidation with rebuilt SDK. #14 fix (ConstructorHandler dispatch + ~Copyable guard hardening) is complete in source.
+
+---
+
+## Open Issues
+
+### 14. Constructor @_cdecl Wrappers Not Applied to Full-Parameter Constructors
+
+**Status**: Done — ConstructorHandler dispatch gap fixed (Bug A), ~Copyable guard hardened (Bug B)
+**Severity**: Critical — blocks ALL struct constructor wrappers, negates fix #10/#12
+
+**Discovery**: Device validation of Lottie with dev SDK (0.0.0-dev) showed LottieColor constructor still SIGSEGV. Investigation revealed:
+
+1. The generated C# for `LottieColor.init(r:g:b:a:denominator:)` still uses `CallConvSwift` with direct import from `"Lottie"` — no `@_cdecl` wrapper was generated.
+2. The generated C# for `LottieConfiguration()` (0-param default overload) correctly uses `CallConvCdecl` with import from `"LottieSwiftBindings"` — wrapper IS present.
+
+**Root cause — two bugs**:
+
+#### Bug A: ConstructorHandler dispatch gap (commit 4228248c)
+
+The `ConstructorWrapperEmitter` integration was added only to the **MethodHandler general method path** (`MethodHandler.cs` line ~709 at commit time), not to `ConstructorHandler.Emit()`. But constructors are dispatched to `ConstructorHandler` via `ConstructorHandlerFactory.Handles()`, so they never reach the general method path.
+
+- `ConstructorHandlerFactory.Handles()` returns `true` for all non-async constructors on StructDecl/ClassDecl (line 43-48)
+- The Conductor tries `ConstructorHandlerFactory` before `MethodHandlerFactory` (line 59-62 in `Conductor.cs`)
+- Result: full-parameter constructors go through `ConstructorHandler.Emit()` which had NO `ShouldEmitWrapper` call
+- Only `DefaultParameterOverloadEmitter`-generated overloads got wrappers because that emitter has its own `ShouldEmitWrapper` call (line 91 in `DefaultParameterOverloadEmitter.cs`)
+
+**Evidence**: In the generated Lottie bindings:
+- `LottieConfiguration` full constructor (4 params) → `CallConvSwift` + `"Lottie"` (no wrapper)
+- `LottieConfiguration()` default overload (0 params) → `CallConvCdecl` + `"LottieSwiftBindings"` (has wrapper)
+- `LottieAnimationView` constructors → all have wrappers (but these are all default-param overloads via `@_silgen_name`)
+- `LottieColor` constructor → `CallConvSwift` + `"Lottie"` (no wrapper, only one constructor, default param handled via C# default value)
+
+**Fix A**: Add `ShouldEmitWrapper` integration to `ConstructorHandler.Emit()` mirroring the general method path. **This fix has already been applied** to the current source (line 322 in `MethodHandler.cs`) but the SDK has not been rebuilt.
+
+#### Bug B: ~Copyable guard blocks ALL struct wrappers
+
+After Bug A was fixed in the source, a `~Copyable` guard was added to `ShouldEmitWrapper()`:
+
+```csharp
+// Lines 46-51 in ConstructorWrapperEmitter.cs
+if (env.ParentDecl is StructDecl structDecl &&
+    structDecl.Conformances.Any(c => c.Protocol.ToString() == "Swift.Escapable"))
+    return false;
+```
+
+The intent was to skip non-copyable types because the current wrapper uses `initializeMemory(as:repeating:count:)` which requires `Copyable` conformance. The assumption was that only `~Copyable` types explicitly list `Escapable`.
+
+**This assumption is wrong**, and conformance-based detection is fundamentally unreliable:
+
+**Problem 1 — `Escapable` presence blocks all structs on newer toolchains.**
+Libraries built with Swift 6.2 (Xcode 26) explicitly list both `Copyable` and `Escapable` on all normal types:
+```json
+// LottieColor (normal copyable struct, Swift 6.2):
+"conformances": [
+  {"name": "Copyable"}, {"name": "Escapable"},
+  {"name": "Hashable"}, {"name": "Equatable"}, ...
+]
+```
+The guard blocks ALL struct constructor wrappers in Lottie, BlinkID, and Stripe.
+
+**Problem 2 — Checking `!Copyable` instead is also wrong.**
+Codex review found that Nuke's ABI JSON (in `swift-bindings/.libraries/`) omits BOTH marker protocols on ordinary structs like `ImageRequest`, `Progress`, `Options`, `UserInfoKey` — even though they are plain `public struct` in the swiftinterface (not `~Copyable`). So `!Copyable` would incorrectly suppress wrappers for normal Nuke structs.
+
+**Root cause of Problem 2 — Swift toolchain version.**
+The marker protocol discrepancy is caused by different Swift compiler versions:
+- `swift-bindings/.libraries/Nuke/` — built with **Swift 5.10** (swiftlang-5.10.0.13, Xcode 15) — ABI JSON does NOT include `Copyable`/`Escapable` conformances
+- `swift-dotnet-packages/libraries/Nuke/` — built with **Swift 6.2** (swiftlang-6.2.3.3.21, Xcode 26) — ABI JSON DOES include `Copyable`/`Escapable` conformances
+
+Marker protocol emission was added to the ABI JSON format between Swift 5.10 and 6.2. Any detection strategy based on conformance presence/absence will produce false results for libraries built with older toolchains.
+
+No confirmed `~Copyable` structs exist in any of the target libraries (Lottie, Nuke, BlinkID, Stripe).
+
+#### Fix B: Harden ~Copyable guard (commit series, current)
+
+The original guard checked `Escapable` conformance on the **parent struct** only. This was unreliable across Swift toolchain versions (see Problems 1 & 2 above). The guard was reworked in three iterations based on code review:
+
+**Iteration 1**: Keep the parent-type `Escapable` conformance guard (for same-module structs where the full `StructDecl` is available), but the real-world toolchain issues above mean this only fires for genuine `~Copyable` types built with Swift 6.2+.
+
+**Iteration 2**: Add `HasNonCopyableStructParameter()` to also guard non-copyable struct **parameters** (not just parent types). Uses `FindStructDecl()` recursive search in `ModuleDecl.Types`.
+
+**Iteration 3**: Fix cross-module parameter detection. `HasNonCopyableStructParameter()` only searched same-module types — cross-module `~Copyable` struct parameters from dependency modules slipped through because `FindStructDecl` returns null. Fix:
+- Added `NonCopyable = 1 << 10` to `TypeRecordFlags`
+- `ModuleProcessor.CacluateFlags()` sets the flag when `StructDecl` has explicit `Swift.Escapable` conformance
+- `ModuleDatabaseEmitter` serializes `nonCopyable="true"` attribute to XML
+- `TypeDatabase.ReadVersion1_0()` deserializes the attribute back to the flag
+- `HasNonCopyableStructParameter()` falls back to `TypeRecord.Flags.HasFlag(NonCopyable)` when `FindStructDecl` returns null (cross-module case)
+
+**Additionally**, all 4 `initializeMemory(as:repeating:count:)` call sites were changed to `assumingMemoryBound(to:).initialize(to:)` (SE-0427, Swift 6.0+), which is universally safe for both `Copyable` and `~Copyable` types. This makes the `~Copyable` guard defense-in-depth rather than load-bearing — if a detection gap appears in the future, the wrapper will still compile correctly.
+
+**Files changed (Bug B)**:
+- `src/Swift.Bindings/src/Emitter/StringEmitter/ConstructorWrapperEmitter.cs` — `ShouldEmitWrapper`, `HasNonCopyableStructParameter`, `FindStructDecl`
+- `src/Swift.Bindings/src/TypeDatabase/TypeRecord.cs` — `NonCopyable` flag
+- `src/Swift.Bindings/src/Parser/ModuleProcessor.cs` — `CacluateFlags()` sets flag
+- `src/Swift.Bindings/src/Emitter/ModuleDatabaseEmitter.cs` — XML serialization
+- `src/Swift.Bindings/src/TypeDatabase/TypeDatabase.cs` — XML deserialization
+- `src/Swift.Bindings/tests/UnitTests/EmitterTests/ConstructorWrapperEmitterTests.cs` (36 tests)
+- `src/Swift.Bindings/tests/UnitTests/EmitterTests/ConstructorHandlerOutputTests.cs` (20 tests)
+- `src/Swift.Bindings/tests/UnitTests/EmitterTests/ModuleDatabaseEmitterTests.cs` (2 round-trip tests)
+
+**After both fixes**: Rebuild SDK package, delete `swift-binding.stamp` in library obj dirs, rebuild libraries, then revalidate on device.
 
 ---
 
@@ -192,7 +301,7 @@ CGRect (32 bytes, 4 Doubles) is passed directly via CallConvSwift. On ARM64 Nati
 
 ### 12. LottieColor Struct Constructor SIGSEGV (Issue 2a)
 
-**Status**: NativeAOT limitation — needs constructor @_cdecl wrappers (same feature as #10)
+**Status**: Done — unblocked by #14 fix, pending device revalidation
 **Severity**: High
 
 **Investigation findings**:
@@ -200,34 +309,41 @@ CGRect (32 bytes, 4 Doubles) is passed directly via CallConvSwift. On ARM64 Nati
 - Generator correctly uses `SwiftIndirectResult` for non-frozen struct return
 - Crash is in NativeAOT runtime's handling of CallConvSwift with large indirect results
 
-**Fix**: Same constructor `@_cdecl` wrapper approach as Issue #10. The wrapper would:
-```swift
-@_cdecl("SBW_Lottie_LottieColor_init")
-public func SBW_Lottie_LottieColor_init(
-    _ resultPtr: UnsafeMutableRawPointer,
-    _ r: Double, _ g: Double, _ b: Double, _ a: Double, _ denominator: Double
-) {
-    let result = Lottie.LottieColor(r: r, g: g, b: b, a: a, denominator: denominator)
-    resultPtr.initializeMemory(as: Lottie.LottieColor.self, repeating: result, count: 1)
-}
-```
-C# side would use `CallingConvention.Cdecl`, allocate a buffer, pass it as `IntPtr`, and read the result.
+**Fix**: Same constructor `@_cdecl` wrapper as #10. The generated wrapper writes the result to an `IntPtr` buffer via `resultPtr.initializeMemory(as:)`, and C# uses `CallingConvention.Cdecl`.
+
+**Pending**: Device revalidation with rebuilt SDK. #14 fix (ConstructorHandler dispatch + ~Copyable guard hardening) is complete in source.
 
 ---
 
-## Future
+### 13. XML Documentation on Generated Types (Issue 9)
 
-### 13. XML Documentation on Generated Types
-
+**Status**: No code change needed — already implemented
 **Severity**: Low — discoverability improvement
 
-Generate XML doc comments from Swift documentation in `.swiftinterface` files.
+The ISSUES.md reported no XML docs, but the generator already has a complete pipeline: symbol graph extraction (`SymbolGraphExtractor`), structured parsing (`SymbolGraphDocParser`), AST attachment via USR keys, and emission (`XmlDocCommentEmitter`) of `/// <summary>`, `<param>`, `<returns>`, and `<remarks>` on all public types, methods, properties, and enum cases. The old NuGet packages were built before this existed.
+
+**Files**: `XmlDocCommentEmitter.cs`, `SymbolGraphDocParser.cs`, `SymbolGraphExtractor.cs`, `DocComment.cs`
 
 ---
 
-## Device Test Results (Round 4 — Current)
+## Device Test Results
 
-### Nuke: 8/8 passed — fully functional
+### Round 5 (Current) — Lottie constructor wrapper validation
+
+Built Lottie test app with dev SDK (`SwiftBindings.Sdk/0.0.0-dev`, `SwiftBindings.Runtime/0.0.0-dev`) and deployed to iPhone 13 (arm64, iOS 26.3.1).
+
+**Result**: SIGSEGV on LottieColor constructor. Crash stack confirms `PInvoke_init_5C5A3370` calling directly into Lottie with `CallConvSwift` — no `@_cdecl` wrapper was generated.
+
+Phase 1 (smoke tests) and Phase 2 (library tests) passed. Phase 3 (constructor tests) crashed:
+- `LottieAnimation.Filepath` — FAIL (`LottieSwiftBindings` DllNotFoundException — wrapper xcframework compilation failed)
+- `LottieColor(1.0, 0.0, 0.0, 1.0)` — SIGSEGV in `PInvoke_init_5C5A3370`
+- `LottieAnimationView(CGRect)` — not reached (crash in prior test)
+
+Investigation led to discovery of #14 (ConstructorHandler dispatch gap + bogus ~Copyable guard).
+
+### Round 4
+
+#### Nuke: 8/8 passed — fully functional
 | Test | Result |
 |------|--------|
 | ImagePipeline.Shared | PASS |
@@ -239,12 +355,12 @@ Generate XML doc comments from Swift documentation in `.swiftinterface` files.
 | DataCache construction | PASS |
 | Image load (network) | PASS |
 
-### Lottie: 4/4 passed, 2 skipped
+#### Lottie: 4/4 passed, 2 blocked
 | Test | Result | Blocker |
 |------|--------|---------|
 | LottieConfiguration.Shared | PASS | |
 | DecodingStrategy enum | PASS | |
 | LottieLoopMode cases | PASS | |
 | LottieAnimation.Filepath | PASS | |
-| LottieAnimationView playback | SKIP | Issue #10 — CGRect struct param SIGSEGV |
-| LottieColor construction | SKIP | Issue #12 — NativeAOT limitation |
+| LottieAnimationView playback | BLOCKED | #14 — constructor wrapper not generated |
+| LottieColor construction | BLOCKED | #14 — constructor wrapper not generated |


### PR DESCRIPTION
## Summary
- **`scripts/ci/sim_manager.py`** — Low-level simulator lifecycle manager wrapping `xcrun simctl` with:
  - Automatic retry with exponential backoff (3 attempts per command)
  - Two-phase readiness detection: poll for `Booted` state + `launchctl print` responsiveness probe (avoids `bootstatus -b` which hangs on GHA runners)
  - Device/runtime auto-discovery with preferred device fallbacks
  - Best-effort cleanup that never raises
  - Structured diagnostic collection (device list, logs, crash reports, Xcode version)

- **`scripts/ci/ci_ios_test.py`** — CI orchestrator that:
  - Runs simulator boot + `dotnet build` in parallel via `ThreadPoolExecutor`
  - Classifies failures as infrastructure (retryable) vs real test failures
  - Retries full simulator setup once on infra failures (fresh simulator on retry)
  - Emits GHA output variables, log groups, and error/warning annotations
  - Uploads diagnostics to `/tmp/sim-diagnostics/` on failure (artifact step in YAML)
  - Delegates actual test execution to existing `run-runtime-tests.sh` (preserves Mono JIT tolerance logic)

- **28 tests** (`test_sim_manager.py`) — Unit tests (mocked subprocess) + integration tests (real simulator lifecycle)

- **Simplified workflows** — `ci.yml` and `release.yml` replaced ~50 lines of inline bash/Python with a single `python3 scripts/ci/ci_ios_test.py` call each

## Before/After

**Before (ci.yml lines 118-168):** 50 lines of inline Python JSON parsing + bash polling loop
**After (ci.yml lines 118-132):** 2 steps — one `python3` call + diagnostic artifact upload

## Test plan
- [ ] CI pipeline passes on this branch (testframework job uses new Python orchestrator)
- [ ] Unit tests pass: `python3 scripts/ci/test_sim_manager.py`
- [ ] Integration tests create/boot/cleanup real simulators successfully
- [ ] Simulator diagnostics uploaded as artifact when tests fail
- [ ] Re-run reliability: trigger workflow_dispatch 3-5x to verify flakiness reduction
- [ ] Manual trigger: `gh workflow run ci.yml --ref feature/ci-simulator-manager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)