### PR TITLE
Reference Swift.Runtime neutral TFM from Swift.Bindings

### DIFF
--- a/src/Swift.Bindings/src/Swift.Bindings.csproj
+++ b/src/Swift.Bindings/src/Swift.Bindings.csproj
@@ -14,7 +14,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="../../Swift.Runtime/src/Swift.Runtime.csproj">
+    <ProjectReference Include="../../Swift.Runtime/src/Swift.Runtime.csproj" SetTargetFramework="TargetFramework=net10.0">
       <ReferenceSourceTarget></ReferenceSourceTarget>
     </ProjectReference>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />


### PR DESCRIPTION
## Background

The Swift.Bindings tool only needs the neutral `net10.0` Swift.Runtime assembly, but Swift.Runtime multi-targets neutral .NET plus Apple platform TFMs.

## Reproduction

Issue: https://github.com/justinwojo/swift-dotnet-bindings/issues/19

On a machine without the macOS workload installed, `dotnet build src/Swift.Bindings/src/Swift.Bindings.csproj` attempts `Swift.Runtime::TargetFramework=net10.0-macos` and fails with `NETSDK1147` before the tool build can complete.

## Fix

Add `SetTargetFramework="TargetFramework=net10.0"` to the Swift.Bindings -> Swift.Runtime project reference so the tool reference is explicitly bound to the neutral runtime TFM.

## Red-to-green tests

This is an MSBuild project-reference fix rather than a generator behavior change. The repro is a build/restore smoke test for the tool project on a machine without the macOS workload.

## Validation

- `git diff --check` passed.
- `dotnet build src/Swift.Bindings/src/Swift.Bindings.csproj -v:minimal 2>&1 | tee /tmp/tool-runtime-tfm-build-tool.txt` was attempted locally. It still reports the existing machine-level `macos` workload failure during restore, so this draft should stay draft until validated on a machine/CI image with the expected workload state or until the upstream project chooses a stronger restore-level narrowing approach.

## Related issue

Fixes #19.

## FirebaseAILogic proof notes

FirebaseAILogic package generation depends on the Swift.Bindings tool building reliably as a neutral tool without requiring unrelated Apple platform workloads.
