### PR TITLE
Pack Swift binding xcframeworks as zipped native assets

### DIFF
--- a/src/Swift.Bindings.Sdk/Sdk/Sdk.targets
+++ b/src/Swift.Bindings.Sdk/Sdk/Sdk.targets
@@ -1639,20 +1639,30 @@ TARGETSEOF"
          this target per-TFM via TargetsForTfmSpecificContentInPackage (set in Sdk.props)
          and collects TfmSpecificPackageFile items. Using None+Pack=true only works in
          single-TFM projects because _GetPackageFiles runs in the outer build context. -->
+    <MakeDir Directories="$(_SwiftBindingIntermediateDir)" />
+    <Exec Command="rm -f &quot;$(MSBuildProjectDirectory)/$(_SwiftBindingIntermediateDir)$(_SwiftBindingModuleName).xcframework.zip&quot; &amp;&amp; /usr/bin/zip -qry &quot;$(MSBuildProjectDirectory)/$(_SwiftBindingIntermediateDir)$(_SwiftBindingModuleName).xcframework.zip&quot; &quot;$([System.IO.Path]::GetFileName('%(SwiftFramework.Identity)'))&quot;"
+          WorkingDirectory="$([System.IO.Path]::GetDirectoryName('%(SwiftFramework.Identity)'))"
+          Condition="'@(SwiftFramework)' != ''" />
+    <Exec Command="rm -f &quot;$(MSBuildProjectDirectory)/$(_SwiftBindingIntermediateDir)$(_SwiftBindingWrapperModuleName).xcframework.zip&quot; &amp;&amp; /usr/bin/zip -qry &quot;$(MSBuildProjectDirectory)/$(_SwiftBindingIntermediateDir)$(_SwiftBindingWrapperModuleName).xcframework.zip&quot; &quot;$(_SwiftBindingWrapperModuleName).xcframework&quot;"
+          WorkingDirectory="$(MSBuildProjectDirectory)/$(_SwiftBindingIntermediateDir)"
+          Condition="'$(_SwiftBindingHasWrapperXCFramework)' == 'True' AND Exists('$(_SwiftBindingIntermediateDir)$(_SwiftBindingWrapperModuleName).xcframework')" />
+    <Exec Command="rm -f &quot;$(MSBuildProjectDirectory)/$(_SwiftBindingIntermediateDir)$(_SwiftBindingBridgeModuleName).xcframework.zip&quot; &amp;&amp; /usr/bin/zip -qry &quot;$(MSBuildProjectDirectory)/$(_SwiftBindingIntermediateDir)$(_SwiftBindingBridgeModuleName).xcframework.zip&quot; &quot;$(_SwiftBindingBridgeModuleName).xcframework&quot;"
+          WorkingDirectory="$(MSBuildProjectDirectory)/$(_SwiftBindingIntermediateDir)"
+          Condition="'$(_SwiftBindingHasBridgeXCFramework)' == 'True' AND Exists('$(_SwiftBindingIntermediateDir)$(_SwiftBindingBridgeModuleName).xcframework')" />
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(_SwiftBindingIntermediateDir)$(PackageId).targets"
             PackagePath="buildTransitive/$(_SwiftBindingPackTfm)/"
             Condition="Exists('$(_SwiftBindingIntermediateDir)$(PackageId).targets')" />
       <!-- Source xcframework (xcframework mode only — Apple-framework mode has no source xcframework) -->
-      <TfmSpecificPackageFile Include="%(SwiftFramework.Identity)/**"
-            PackagePath="runtimes/$(_SwiftBindingNuGetRid)/native/$([System.IO.Path]::GetFileName('%(SwiftFramework.Identity)'))/"
-            Condition="'@(SwiftFramework)' != ''" />
-      <TfmSpecificPackageFile Include="$(_SwiftBindingIntermediateDir)$(_SwiftBindingWrapperModuleName).xcframework/**"
-            PackagePath="runtimes/$(_SwiftBindingNuGetRid)/native/$(_SwiftBindingWrapperModuleName).xcframework/"
-            Condition="'$(_SwiftBindingHasWrapperXCFramework)' == 'True'" />
-      <TfmSpecificPackageFile Include="$(_SwiftBindingIntermediateDir)$(_SwiftBindingBridgeModuleName).xcframework/**"
-            PackagePath="runtimes/$(_SwiftBindingNuGetRid)/native/$(_SwiftBindingBridgeModuleName).xcframework/"
-            Condition="'$(_SwiftBindingHasBridgeXCFramework)' == 'True'" />
+      <TfmSpecificPackageFile Include="$(_SwiftBindingIntermediateDir)$(_SwiftBindingModuleName).xcframework.zip"
+            PackagePath="runtimes/$(_SwiftBindingNuGetRid)/native/"
+            Condition="'@(SwiftFramework)' != '' AND Exists('$(_SwiftBindingIntermediateDir)$(_SwiftBindingModuleName).xcframework.zip')" />
+      <TfmSpecificPackageFile Include="$(_SwiftBindingIntermediateDir)$(_SwiftBindingWrapperModuleName).xcframework.zip"
+            PackagePath="runtimes/$(_SwiftBindingNuGetRid)/native/"
+            Condition="'$(_SwiftBindingHasWrapperXCFramework)' == 'True' AND Exists('$(_SwiftBindingIntermediateDir)$(_SwiftBindingWrapperModuleName).xcframework.zip')" />
+      <TfmSpecificPackageFile Include="$(_SwiftBindingIntermediateDir)$(_SwiftBindingBridgeModuleName).xcframework.zip"
+            PackagePath="runtimes/$(_SwiftBindingNuGetRid)/native/"
+            Condition="'$(_SwiftBindingHasBridgeXCFramework)' == 'True' AND Exists('$(_SwiftBindingIntermediateDir)$(_SwiftBindingBridgeModuleName).xcframework.zip')" />
       <!-- Module database for cross-module type resolution in downstream binding projects -->
       <TfmSpecificPackageFile Include="$(_SwiftBindingIntermediateDir)$(_SwiftBindingModuleName)Database.xml"
             PackagePath="buildTransitive/$(_SwiftBindingPackTfm)/"

--- a/src/Swift.Bindings/src/Emitter/ConsumerTargetsEmitter.cs
+++ b/src/Swift.Bindings/src/Emitter/ConsumerTargetsEmitter.cs
@@ -55,8 +55,8 @@ namespace BindingsGeneration
 
             var wrapperNativeRef = options.HasWrapperXCFramework
                 ? $"""
-                          <NativeReference Include="$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}SwiftBindings.xcframework"
-                                           Condition="Exists('$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}SwiftBindings.xcframework')">
+                          <NativeReference Include="$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}SwiftBindings.xcframework.zip"
+                                           Condition="Exists('$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}SwiftBindings.xcframework.zip')">
                             <Kind>Framework</Kind>
                           </NativeReference>
                 """
@@ -64,8 +64,8 @@ namespace BindingsGeneration
 
             var bridgeNativeRef = options.HasBridgeXCFramework
                 ? $"""
-                          <NativeReference Include="$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}Bridge.xcframework"
-                                           Condition="Exists('$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}Bridge.xcframework')">
+                          <NativeReference Include="$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}Bridge.xcframework.zip"
+                                           Condition="Exists('$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}Bridge.xcframework.zip')">
                             <Kind>Framework</Kind>
                           </NativeReference>
                 """
@@ -115,8 +115,8 @@ namespace BindingsGeneration
                       <_SwiftBinding_{sanitized}_Injected>true</_SwiftBinding_{sanitized}_Injected>
                     </PropertyGroup>
                     <ItemGroup>
-                      <NativeReference Include="$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}.xcframework"
-                                       Condition="Exists('$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}.xcframework')">
+                      <NativeReference Include="$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}.xcframework.zip"
+                                       Condition="Exists('$(MSBuildThisFileDirectory)../../runtimes/{pi.NuGetRid}/native/{options.ModuleName}.xcframework.zip')">
                         <Kind>Framework</Kind>
                       </NativeReference>
                 {wrapperNativeRef}{bridgeNativeRef}{resourceBundleItems}    </ItemGroup>

--- a/src/Swift.Bindings/tests/UnitTests/EmitterTests/ConsumerTargetsEmitterTests.cs
+++ b/src/Swift.Bindings/tests/UnitTests/EmitterTests/ConsumerTargetsEmitterTests.cs
@@ -345,7 +345,7 @@ namespace BindingsGeneration.Tests
             try
             {
                 var content = EmitAndRead(dir, "Nuke", "Nuke.Swift.iOS", "15.0", hasWrapper: false);
-                Assert.Contains("Condition=\"Exists('$(MSBuildThisFileDirectory)../../runtimes/ios-arm64/native/Nuke.xcframework')\"", content);
+                Assert.Contains("Condition=\"Exists('$(MSBuildThisFileDirectory)../../runtimes/ios-arm64/native/Nuke.xcframework.zip')\"", content);
             }
             finally { Directory.Delete(dir, true); }
         }
@@ -357,7 +357,7 @@ namespace BindingsGeneration.Tests
             try
             {
                 var content = EmitAndRead(dir, "Nuke", "Nuke.Swift.iOS", "15.0", hasWrapper: true);
-                Assert.Contains("Condition=\"Exists('$(MSBuildThisFileDirectory)../../runtimes/ios-arm64/native/NukeSwiftBindings.xcframework')\"", content);
+                Assert.Contains("Condition=\"Exists('$(MSBuildThisFileDirectory)../../runtimes/ios-arm64/native/NukeSwiftBindings.xcframework.zip')\"", content);
             }
             finally { Directory.Delete(dir, true); }
         }
@@ -369,8 +369,8 @@ namespace BindingsGeneration.Tests
             try
             {
                 var content = EmitAndRead(dir, "TestLib", "TestLib.Swift.iOS", "15.0", hasWrapper: true);
-                Assert.Contains("../../runtimes/ios-arm64/native/TestLib.xcframework", content);
-                Assert.Contains("../../runtimes/ios-arm64/native/TestLibSwiftBindings.xcframework", content);
+                Assert.Contains("../../runtimes/ios-arm64/native/TestLib.xcframework.zip", content);
+                Assert.Contains("../../runtimes/ios-arm64/native/TestLibSwiftBindings.xcframework.zip", content);
             }
             finally { Directory.Delete(dir, true); }
         }


### PR DESCRIPTION
## Background

Swift binding packages that target multiple Apple TFMs need a stable, TFM/RID-specific native layout. Raw `.xcframework` directory packing is fragile for multi-TFM NuGet packages, and consumer targets should point at the packaged asset shape.

## Reproduction

Issue: https://github.com/justinwojo/swift-dotnet-bindings/issues/27

Pack a multi-TFM Swift binding project that produces source and wrapper xcframeworks. The generated package/targets currently use raw `.xcframework` directory paths instead of zipped native assets.

## Fix

Zip source, wrapper, and bridge xcframework directories during `_ConfigureSwiftBindingPack`, add the zips as `TfmSpecificPackageFile` entries, and update `ConsumerTargetsEmitter` to emit `.xcframework.zip` NativeReference paths.

## Red-to-green tests

Updated `ConsumerTargetsEmitterTests` expectations so generated consumer targets reference `.xcframework.zip` native assets for source and wrapper frameworks.

## Validation

- `git diff --check` passed.
- `dotnet nuke pack --version 0.0.0-smoke --output-dir /tmp/swift-nuget 2>&1 | tee /tmp/zipped-xcframework-pack-nuke-pack.txt` was attempted. It hit the existing local `NETSDK1147` macOS workload blocker during compile before pack ran.

## Related issue

Fixes #27.

## FirebaseAILogic proof notes

This packaging shape is needed for a FirebaseAILogic NuGet package that carries generated iOS and Mac Catalyst Swift binding native assets and can be consumed by an app project.
